### PR TITLE
Tambahkan filter tahun pada statistik kesehatan & jaminan sosial data presisi

### DIFF
--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -4,7 +4,7 @@ Di rilis ini, versi 2603.0.0 berisi penambahan dan perbaikan yang diminta penggu
 
 1. [#946](https://github.com/OpenSID/OpenKab/issues/946) Penambahan filter tahun pada statistik papan & sandang data presisi.
 2. [#948](https://github.com/OpenSID/OpenKab/issues/948) Penambahan filter tahun pada statistik seni budaya & pendidikan data presisi.
-
+3. [#952](https://github.com/OpenSID/OpenKab/issues/952) Penambahan filter tahun pada statistik Aktivitas Keagamaan, ketenagakerjaan dan adat data presisi.
 
 #### Perbaikan BUG
 

--- a/resources/views/presisi/statistik/jaminan-sosial.blade.php
+++ b/resources/views/presisi/statistik/jaminan-sosial.blade.php
@@ -34,12 +34,7 @@
                         <h3 id="title-block"></h3>
                     </div>
                     <div class="row">
-                        <div class="col-auto">
-                            <a class="btn btn-sm btn-secondary" data-toggle="collapse" href="#collapse-filter" role="button"
-                                aria-expanded="true" aria-controls="collapse-filter">
-                                <i class="fas fa-filter"></i>
-                            </a>
-                        </div>
+                        <x-filter-tahun />
 
                         <div class="col-md-2">
                             <button type="button" id="export-excel" class="btn btn-info btn-block btn-sm">
@@ -193,7 +188,7 @@
                 // Get current active category
                 var activeCategory = $('#daftar-statistik .active');
                 var categoryName = activeCategory.data('nama') || 'Statistik';
-                var tahun = $("#tahun").val();
+                var tahun = $("#filter-tahun").val();
                 var bulan = $("#bulan").val();
 
                 // Generate dynamic filename
@@ -345,6 +340,7 @@
                     method: 'get',
                     data: function (row) {
                         return {
+                            "tahun": $('#filter-tahun').val(),
                             "sort": (row.order[0]?.dir === "asc" ? "" : "-") + row.columns[row
                                 .order[0]
                                 ?.column]
@@ -361,7 +357,9 @@
                                 })
                             })
 
-                            grafikPie()
+                            if (data_grafik.length > 2) {
+                                grafikPie()
+                            }
 
                             return json.data;
                         }
@@ -394,6 +392,7 @@
                             let urlDetail = new URL(urlDetailLink);
                             urlDetail.searchParams.set('filter[nilai]', nilai);
                             urlDetail.searchParams.set('judul', judul);
+                            urlDetail.searchParams.set('tahun', $('#filter-tahun').val());
                             urlDetail.searchParams.set('nama', nilai);
                             urlDetail.searchParams.set('tipe', $('.pilih-kategori > a.active')
                                 .text().trim());
@@ -438,8 +437,9 @@
                 });
             });
 
-            $('#filter').on('click', function (e) {
-                statistik.draw();
+            // Event listener for year filter change
+            $('#filter-tahun').on('change', function () {
+                statistik.ajax.reload();
             });
 
             $(document).on('click', '#reset', function (e) {

--- a/resources/views/presisi/statistik/kesehatan.blade.php
+++ b/resources/views/presisi/statistik/kesehatan.blade.php
@@ -34,12 +34,7 @@
                         <h3 id="title-block"></h3>
                     </div>
                     <div class="row">
-                        <div class="col-auto">
-                            <a class="btn btn-sm btn-secondary" data-toggle="collapse" href="#collapse-filter" role="button"
-                                aria-expanded="true" aria-controls="collapse-filter">
-                                <i class="fas fa-filter"></i>
-                            </a>
-                        </div>
+                        <x-filter-tahun />
 
                         <div class="col-md-2">
                             <button type="button" id="export-excel" class="btn btn-info btn-block btn-sm">
@@ -193,7 +188,7 @@
                 // Get current active category
                 var activeCategory = $('#daftar-statistik .active');
                 var categoryName = activeCategory.data('nama') || 'Statistik';
-                var tahun = $("#tahun").val();
+                var tahun = $("#filter-tahun").val();
                 var bulan = $("#bulan").val();
 
                 // Generate dynamic filename
@@ -345,6 +340,7 @@
                     method: 'get',
                     data: function (row) {
                         return {
+                            "tahun": $('#filter-tahun').val(),
                             "sort": (row.order[0]?.dir === "asc" ? "" : "-") + row.columns[row
                                 .order[0]
                                 ?.column]
@@ -361,7 +357,9 @@
                                 })
                             })
 
-                            grafikPie()
+                            if (data_grafik.length > 2) {
+                                grafikPie()
+                            }
 
                             return json.data;
                         }
@@ -394,6 +392,7 @@
                             let urlDetail = new URL(urlDetailLink);
                             urlDetail.searchParams.set('filter[nilai]', nilai);
                             urlDetail.searchParams.set('judul', judul);
+                            urlDetail.searchParams.set('tahun', $('#filter-tahun').val());
                             urlDetail.searchParams.set('nama', nilai);
                             urlDetail.searchParams.set('tipe', $('.pilih-kategori > a.active')
                                 .text().trim());
@@ -438,8 +437,9 @@
                 });
             });
 
-            $('#filter').on('click', function (e) {
-                statistik.draw();
+            // Event listener for year filter change
+            $('#filter-tahun').on('change', function () {
+                statistik.ajax.reload();
             });
 
             $(document).on('click', '#reset', function (e) {


### PR DESCRIPTION
Perbaikan issue #950 
Bergantung pada PR https://github.com/OpenSID/API-Database-Gabungan/pull/331

## Detail Perubahan per File

### 1. resources/views/presisi/statistik/jaminan-sosial.blade.php
- **Status**: Dimodifikasi (Modified)
- **Perubahan**: +10 baris, -10 baris

#### Perubahan Utama:
1. **Penggantian Filter Tahun**:
   - Menghapus tombol filter collapse yang lama (baris 36-42)
   - Menambahkan komponen `<x-filter-tahun />` untuk filter tahun yang lebih konsisten

2. **Pembaruan Referensi ID Filter**:
   - Mengubah `$("#tahun").val()` menjadi `$("#filter-tahun").val()` pada fungsi exportToExcel (baris 191)
   - Menambahkan parameter `"tahun": $('#filter-tahun').val()` pada data request DataTable (baris 343)
   - Menambahkan parameter tahun pada URL detail (baris 395)

3. **Penambahan Event Listener**:
   - Mengubah event listener dari `$('#filter').on('click')` menjadi `$('#filter-tahun').on('change')` (baris 440-442)
   - Mengubah dari `statistik.draw()` menjadi `statistik.ajax.reload()` untuk me-reload data tabel

4. **Perbaikan Logika Grafik**:
   - Menambahkan kondisi `if (data_grafik.length > 2)` sebelum memanggil `grafikPie()` untuk mencegah error saat data kurang dari 3 (baris 359-361)

### 2. resources/views/presisi/statistik/kesehatan.blade.php
- **Status**: Dimodifikasi (Modified)
- **Perubahan**: +10 baris, -10 baris

#### Perubahan Utama:
1. **Penggantian Filter Tahun**:
   - Menghapus tombol filter collapse yang lama (baris 36-42)
   - Menambahkan komponen `<x-filter-tahun />` untuk filter tahun yang lebih konsisten

2. **Pembaruan Referensi ID Filter**:
   - Mengubah `$("#tahun").val()` menjadi `$("#filter-tahun").val()` pada fungsi exportToExcel (baris 191)
   - Menambahkan parameter `"tahun": $('#filter-tahun').val()` pada data request DataTable (baris 343)
   - Menambahkan parameter tahun pada URL detail (baris 395)

3. **Penambahan Event Listener**:
   - Mengubah event listener dari `$('#filter').on('click')` menjadi `$('#filter-tahun').on('change')` (baris 440-442)
   - Mengubah dari `statistik.draw()` menjadi `statistik.ajax.reload()` untuk me-reload data tabel

4. **Perbaikan Logika Grafik**:
   - Menambahkan kondisi `if (data_grafik.length > 2)` sebelum memanggil `grafikPie()` untuk mencegah error saat data kurang dari 3 (baris 359-361)

## Komponen Tambahan

### resources/views/components/filter-tahun.blade.php
- **Status**: Tidak berubah antara kedua branch
- **Fungsi**: Komponen Blade untuk filter tahun yang digunakan pada kedua halaman statistik
- **Fitur**:
  - Menampilkan dropdown pilihan tahun dari tahun saat ini hingga 5 tahun ke belakang
  - Mendukung parameter `$selectedYear` untuk menentukan tahun yang dipilih secara default

## Analisis Perubahan

### Tujuan Utama Perubahan:
1. **Standardisasi Filter Tahun**: Mengganti implementasi filter tahun yang berbeda-beda dengan komponen yang konsisten (`<x-filter-tahun />`)
2. **Perbaikan Fungsionalitas**: Memastikan filter tahun berfungsi dengan baik pada kedua halaman statistik
3. **Penanganan Error**: Menambahkan validasi untuk mencegah error pada grafik pie saat data tidak mencukupi
4. **Konsistensi ID**: Menggunakan ID yang konsisten (`filter-tahun`) untuk elemen filter tahun
5. **Optimasi Event Handling**: Mengubah dari event click ke change dan menggunakan ajax.reload() untuk performa yang lebih baik

### Dampak Perubahan:
1. **UI/UX**: Pengalaman pengguna yang lebih konsisten pada halaman statistik
2. **Maintainability**: Penggunaan komponen yang dapat digunakan kembali (reusable) memudahkan pemeliharaan
3. **Stabilitas**: Mengurangi kemungkinan error pada tampilan grafik
4. **Performa**: Menggunakan ajax.reload() yang lebih efisien daripada draw()

https://github.com/user-attachments/assets/bb2bdb2b-2509-458e-9ebe-205aebdb6e96

