### PR TITLE
fix: tambahkan judul dan kategori ketika hapus artikel

### DIFF
--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -6,6 +6,8 @@ Di rilis ini, versi 2604.0.0 berisi penambahan dan perbaikan yang diminta penggu
 2. [#948](https://github.com/OpenSID/OpenKab/issues/948) Penambahan filter tahun pada statistik seni budaya & pendidikan data presisi.
 3. [#952](https://github.com/OpenSID/OpenKab/issues/952) Penambahan filter tahun pada statistik Aktivitas Keagamaan, ketenagakerjaan dan adat data presisi.
 4. [#942](https://github.com/OpenSID/OpenKab/issues/942) Penambahan fitur menampilkan artikel OpenSID di halaman publik.
+5. [#372](https://github.com/OpenSID/API-Database-Gabungan/issues/372) Penambahan judul dan kategori ketika hapus artikel.
+
 
 #### Perbaikan BUG
 

--- a/resources/views/master/artikel/index.blade.php
+++ b/resources/views/master/artikel/index.blade.php
@@ -95,10 +95,11 @@
                             let canEdit = `{{ $canedit }}`
                             let canDelete = `{{ $candelete }}`
                             var id = row.id;
+                            let titleDelete = `Apakah anda yakin menghapus artikel dengan judul <strong>${row.attributes.judul}</strong> kategori <strong>${row.attributes.kategori_nama}</strong> ?`
                             let buttonEdit = canEdit ? `<a href="{{ route('master-data-artikel.index') }}/${id}/edit" class="btn btn-warning btn-sm" title="Edit">
                                     <i class="fas fa-edit"></i>
                                 </a>` : ``;
-                            let buttonDelete = canDelete ? `<button type="button" class="btn btn-danger btn-sm hapus" data-id="${id}" title="Hapus">
+                            let buttonDelete = canDelete ? `<button type="button" class="btn btn-danger btn-sm hapus" data-id="${id}" data-title-delete="${titleDelete}" title="Hapus">
                                     <i class="fas fa-trash"></i>
                                 </button>` : ``;
                             return `${buttonEdit} ${buttonDelete}`;
@@ -145,10 +146,11 @@
 
             $(document).on('click', 'button.hapus', function() {
                 var id = $(this).data('id')
+                let titleDelete = $(this).data('title-delete')
                 var that = $(this);
                 Swal.fire({
                     title: 'Hapus',
-                    text: "Apakah anda yakin menghapus artikel ini?",
+                    html: titleDelete,
                     icon: 'warning',
                     showCancelButton: true,
                     confirmButtonText: 'Hapus'

--- a/resources/views/master/artikel/index.blade.php
+++ b/resources/views/master/artikel/index.blade.php
@@ -95,7 +95,7 @@
                             let canEdit = `{{ $canedit }}`
                             let canDelete = `{{ $candelete }}`
                             var id = row.id;
-                            let titleDelete = `Apakah anda yakin menghapus artikel dengan judul <strong>${row.attributes.judul}</strong> kategori <strong>${row.attributes.kategori_nama}</strong> ?`
+                            let titleDelete = `Apakah anda yakin menghapus artikel dengan judul ${row.attributes.judul} - kategori ${row.attributes.kategori_nama} ?`
                             let buttonEdit = canEdit ? `<a href="{{ route('master-data-artikel.index') }}/${id}/edit" class="btn btn-warning btn-sm" title="Edit">
                                     <i class="fas fa-edit"></i>
                                 </a>` : ``;
@@ -150,7 +150,7 @@
                 var that = $(this);
                 Swal.fire({
                     title: 'Hapus',
-                    html: titleDelete,
+                    text: titleDelete,
                     icon: 'warning',
                     showCancelButton: true,
                     confirmButtonText: 'Hapus'


### PR DESCRIPTION
## Summary
Perbaikan pada konfirmasi hapus artikel untuk menampilkan detail judul dan kategori artikel yang akan dihapus

## Perubahan
File yang diubah: `resources/views/master/artikel/index.blade.php`

1. **Menambahkan variabel titleDelete** (baris 98)
   - Menyimpan pesan konfirmasi dengan detail judul dan kategori artikel
   - Menggunakan format HTML untuk penekanan teks

2. **Menambahkan atribut data-title-delete** (baris 102)
   - Melewatkan pesan konfirmasi melalui data attribute pada tombol hapus
   - Nilai di-generate secara dinamis berdasarkan data artikel tiap baris

3. **Memperbaiki event handler tombol hapus** (baris 149, 153)
   - Mengambil pesan dari data attribute `data-title-delete`
   - Mengganti `text` menjadi `html` pada SweetAlert untuk render format teks dengan benar

## Alasan Perubahan
Sebelumnya konfirmasi hapus hanya menampilkan pesan umum "Apakah anda yakin menghapus artikel ini?" tanpa informasi artikel mana yang akan dihapus. Pengguna tidak dapat memverifikasi bahwa artikel yang benar terpilih sebelum melakukan aksi hapus.

## Issue
https://github.com/OpenSID/API-Database-Gabungan/issues/372

<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/55fd5d59-1c88-496d-898f-3d1c2b5e9c59" />
