### PR TITLE
Validasi kategori artikel ketika membuat artikel baru

### DIFF
--- a/app/Http/Controllers/Master/ArtikelKabupatenController.php
+++ b/app/Http/Controllers/Master/ArtikelKabupatenController.php
@@ -32,7 +32,9 @@ class ArtikelKabupatenController extends Controller
      */
     public function create(): View
     {
-        return view('master.artikel.create');
+        $listPermission = $this->generateListPermission();
+
+        return view('master.artikel.create')->with($listPermission);
     }
 
     /**

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -14,6 +14,7 @@ Di rilis ini, versi 2604.0.1 berisi penambahan dan perbaikan yang diminta penggu
 
 #### Perbaikan BUG
 1. [#1023](https://github.com/OpenSID/OpenKab/issues/1023) Percobaan login gagal terkadang error 500
+2. [#1025](https://github.com/OpenSID/OpenKab/issues/1025) Arahkan/Infokan pembuatan kategori artikel ketika kategori kosong saat membuat artikel opensid
 
 #### Perubahan Teknis
 

--- a/resources/views/master/artikel/create.blade.php
+++ b/resources/views/master/artikel/create.blade.php
@@ -68,6 +68,14 @@
                                     <select class="form-control select2" id="id_kategori" name="id_kategori" required>
                                         <option value="">-- Pilih Kategori --</option>
                                     </select>
+                                    <small id="empty-kategori-hint" class="form-text text-danger d-none">
+                                        Kategori artikel belum tersedia.
+                                        @if (($canwrite ?? 0) == 1)
+                                            <a href="{{ url('master/kategori/tambah/0') }}">Buat kategori artikel sekarang</a>.
+                                        @else
+                                            Silakan hubungi admin untuk menambahkan kategori.
+                                        @endif
+                                    </small>
                                 </div>
 
                                 <!-- Tanggal Upload -->
@@ -119,6 +127,8 @@
     @include('partials.asset_tinymce')
     <script nonce="{{ csp_nonce() }}">
         const header = @include('layouts.components.header_bearer_api_gabungan');
+        const canCreateKategori = {{ (($canwrite ?? 0) == 1) ? 'true' : 'false' }};
+        const kategoriCreateUrl = "{{ url('master/kategori/tambah/0') }}";
 
         function artikel() {
             return {
@@ -135,6 +145,8 @@
                 fileData: {
                     gambar: null
                 },
+                hasKategori: true,
+                hasShownKategoriKosongPopup: false,
 
                 init() {
                     this.loadKategori();
@@ -162,7 +174,7 @@
                     formData.append('file', file);
 
                     try {
-                        const response = await fetch('{{ route('artikel.upload_gambar') }}', {
+                        const response = await fetch("{{ route('artikel.upload_gambar') }}", {
                             method: 'POST',
                             headers: {
                                 'X-CSRF-TOKEN': '{{ csrf_token() }}'
@@ -202,15 +214,29 @@
                         },
                         success: function(response) {
                             const select = $('#id_kategori');
+                            const hint = $('#empty-kategori-hint');
                             select.empty();
                             select.append('<option value="">-- Pilih Kategori --</option>');
 
-                            if (response.data) {
-                                response.data.forEach(function(item) {
+                            const kategoriItems = Array.isArray(response.data) ? response.data : [];
+
+                            if (kategoriItems.length > 0) {
+                                self.hasKategori = true;
+                                self.hasShownKategoriKosongPopup = false;
+                                hint.addClass('d-none');
+                                select.prop('disabled', false);
+
+                                kategoriItems.forEach(function(item) {
                                     select.append(
                                         `<option value="${item.id}">${item.attributes.kategori}</option>`
                                     );
                                 });
+                            } else {
+                                self.hasKategori = false;
+                                self.dataArtikel.id_kategori = '';
+                                hint.removeClass('d-none');
+                                select.prop('disabled', true);
+                                self.showKategoriKosongInfo();
                             }
 
                             select.select2({
@@ -227,6 +253,37 @@
                         error: function(xhr) {
                             console.error('Error loading kategori:', xhr);
                         }
+                    });
+                },
+
+                showKategoriKosongInfo() {
+                    if (this.hasShownKategoriKosongPopup) {
+                        return;
+                    }
+
+                    this.hasShownKategoriKosongPopup = true;
+
+                    if (canCreateKategori) {
+                        Swal.fire({
+                            icon: 'info',
+                            title: 'Kategori Belum Tersedia',
+                            text: 'Kategori artikel wajib diisi. Buat kategori artikel terlebih dahulu sebelum menambahkan artikel.',
+                            showCancelButton: true,
+                            confirmButtonText: 'Buat Kategori',
+                            cancelButtonText: 'Nanti Saja'
+                        }).then((result) => {
+                            if (result.isConfirmed) {
+                                window.location.href = kategoriCreateUrl;
+                            }
+                        });
+
+                        return;
+                    }
+
+                    Swal.fire({
+                        icon: 'info',
+                        title: 'Kategori Belum Tersedia',
+                        text: 'Kategori artikel wajib diisi. Silakan hubungi admin untuk menambahkan kategori artikel terlebih dahulu.'
                     });
                 },
 
@@ -253,6 +310,12 @@
                         return;
                     }
                     if (!this.dataArtikel.id_kategori) {
+                        if (!this.hasKategori) {
+                            Swal.fire('Info', 'Kategori artikel belum tersedia. Buat kategori terlebih dahulu sebelum menyimpan artikel.',
+                                'info');
+                            return;
+                        }
+
                         Swal.fire('Error!', 'Kategori harus dipilih', 'error');
                         return;
                     }
@@ -302,7 +365,7 @@
                                 });
                                 setTimeout(() => {
                                     window.location.href =
-                                        '{{ route('master-data-artikel.index') }}?clear_all_cache=1';
+                                        "{{ route('master-data-artikel.index') }}?clear_all_cache=1";
                                 }, 1500);
                             } else {
                                 Swal.fire({

--- a/tests/Feature/ArtikelControllerTest.php
+++ b/tests/Feature/ArtikelControllerTest.php
@@ -22,10 +22,22 @@ class ArtikelControllerTest extends BaseTestCase
         $response = $this->get(route('master-data-artikel.create'));
         $response->assertStatus(200);
         $response->assertViewIs('master.artikel.create');
+        $response->assertViewHas(['canwrite', 'canedit', 'candelete']);
         $response->assertSee('Tambah Artikel');
         $response->assertSee('Judul Artikel');
         $response->assertSee('Isi Artikel');
         $response->assertSee('Kategori');
+    }
+
+    /** @test */
+    public function artikel_create_has_empty_kategori_popup_guard()
+    {
+        $response = $this->get(route('master-data-artikel.create'));
+        $response->assertStatus(200);
+
+        $response->assertSee('hasShownKategoriKosongPopup: false', false);
+        $response->assertSee('if (this.hasShownKategoriKosongPopup)', false);
+        $response->assertSee('this.hasShownKategoriKosongPopup = true', false);
     }
 
     /** @test */


### PR DESCRIPTION
issue https://github.com/OpenSID/OpenKab/issues/1025

## Ringkasan
- Menambahkan alur panduan saat kategori artikel kosong di halaman tambah artikel (`/master/artikel/create`).
- Menampilkan popup informasi bahwa kategori wajib dibuat terlebih dahulu, dengan tombol aksi ke halaman pembuatan kategori (`/master/kategori/tambah/0`) untuk user yang memiliki izin.
- Menambahkan hint inline pada field kategori, menonaktifkan dropdown saat data kategori kosong, dan memblokir submit artikel dengan pesan yang lebih jelas.

## Perubahan Utama
- `app/Http/Controllers/Master/ArtikelKabupatenController.php`
  - Method `create()` sekarang mengirim `listPermission` ke view agar kontrol UI berbasis izin (`canwrite`) bisa digunakan.
- `resources/views/master/artikel/create.blade.php`
  - Menambahkan elemen info `empty-kategori-hint` di bawah dropdown kategori.
  - Menambahkan logika deteksi kategori kosong dari response API.
  - Menambahkan popup `SweetAlert` untuk mengarahkan pembuatan kategori (atau info hubungi admin bila tanpa izin).
  - Menambahkan guard popup (`hasShownKategoriKosongPopup`) agar popup tidak muncul berulang/dua kali.
  - Menambahkan validasi submit agar user mendapat pesan spesifik ketika kategori memang belum tersedia.

## Dampak
- UX pembuatan artikel pertama kali menjadi lebih jelas ketika kategori belum ada.
- Mengurangi kebingungan user karena field wajib kategori kini disertai arahan tindakan yang langsung dapat dilakukan.

## Pengujian
- Menambahkan test sederhana di `tests/Feature/ArtikelControllerTest.php`:
  - `it_can_access_artikel_create()` diperbarui untuk memastikan permission tersedia di view.
  - `artikel_create_has_empty_kategori_popup_guard()` untuk memastikan guard popup tersedia di script.
- Menjalankan test:
  - `php artisan test --filter=ArtikelControllerTest`
  - Hasil: **PASS** (13 tests, 51 assertions).
