### PR TITLE
Feat: menambahkan fitur download excel pada presisi papan

### DIFF
--- a/app/Http/Controllers/DataPresisiPapanController.php
+++ b/app/Http/Controllers/DataPresisiPapanController.php
@@ -26,4 +26,16 @@ class DataPresisiPapanController extends Controller
 
         return view('data_pokok.data_presisi.papan.detail_data', compact('title', 'colomn'));
     }
+
+    public function cetak(Request $request): View
+    {
+        return view('data_pokok.data_presisi.papan.cetak', ['filter' => $request->getQueryString()]);
+    }
+
+     public function detail(Request $request): View
+    {
+        $data = json_decode($request->data);
+
+        return view('data_pokok.data_presisi.papan.detail', ['data' => $data]);
+    }
 }

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -1,32 +1,13 @@
-Di rilis ini, versi 2605.0.1 berisi penambahan dan perbaikan yang diminta pengguna.
+Di rilis ini, versi 2606.0.1 berisi penambahan dan perbaikan yang diminta pengguna.
 
 #### Penambahan Fitur
 
-1. [#997](https://github.com/OpenSID/OpenKab/issues/997) Buat Halaman Detail Pangan di Statistik Presisi
-2. [#1003](https://github.com/OpenSID/OpenKab/issues/1003) Buat Halaman Detail Sandang di Statistik Presisi
-3. [#1004](https://github.com/OpenSID/OpenKab/issues/1004) Buat Halaman Detail Papan di Statistik Presisi
-4. [#1002](https://github.com/OpenSID/OpenKab/issues/1002) Buat Halaman Detail Pendidikan di Statistik Presisi
-5. [#1001](https://github.com/OpenSID/OpenKab/issues/1001) Buat Halaman Detail Ketenagakerjaan di Statistik Presisi
-6. [#1000](https://github.com/OpenSID/OpenKab/issues/1000) Buat Halaman Detail Keagamaan di Statistik Presisi
-7. [#999](https://github.com/OpenSID/OpenKab/issues/999) Buat Halaman Detail Jaminan Sosial di Statistik Presisi
-8. [#998](https://github.com/OpenSID/OpenKab/issues/998) Buat Halaman Detail Kesehatan di Statistik Presisi
-9. [#1005](https://github.com/OpenSID/OpenKab/issues/1005) Buat Halaman Detail Seni di Statistik Presisi
-10. [#1021](https://github.com/OpenSID/OpenKab/issues/1021) Ubah field isi artikel menjadi rich editor
-11. [#1025](https://github.com/OpenSID/OpenKab/issues/1025) Arahkan/Infokan pembuatan kategori artikel ketika kategori kosong saat membuat artikel opensid
-12. [#1031](https://github.com/OpenSID/OpenKab/issues/1031) Arahkan/Infokan pembuatan kategori artikel ketika kategori kosong saat membuat artikel di pengaturan web -> artikel
-13. [#1041](https://github.com/OpenSID/OpenKab/issues/1041) Tambahkan fungsi global untuk debounce search datatable
-
-
+1. [#1047](https://github.com/OpenSID/OpenKab/issues/1047) Tambahkan fitur export excel di menu data presisi -> Papan
 
 #### Perbaikan BUG
-1. [#1023](https://github.com/OpenSID/OpenKab/issues/1023) Percobaan login gagal terkadang error 500
-2. [#1026](https://github.com/OpenSID/OpenKab/issues/1026) Perbaikan fungsi insert media dan gambar pada tinymce artikel 
-3. [#1032](https://github.com/OpenSID/OpenKab/issues/1032) Perbaikan Tombol enter refresh halaman di kategori artikel opensid
-4. [#1037](https://github.com/OpenSID/OpenKab/issues/1037) Perbaikan Gambar desa aktif pada halaman website openkab masih statis
-5. [#1039](https://github.com/OpenSID/OpenKab/issues/1039) Perbaikan Tampilan halaman web ketika belum ditambahkan gambar slider tidak tampil dengan baik
-
-#### Perubahan Teknis
 
 
 #### Perubahan Teknis
+
+
 

--- a/resources/views/data_pokok/data_presisi/papan/cetak.blade.php
+++ b/resources/views/data_pokok/data_presisi/papan/cetak.blade.php
@@ -15,14 +15,18 @@
     <table class="border thick" id="tabel-papan">
         <thead>
             <tr class="border thick">
-                <th>No</th>
+                <th>NO</th>
                 <th>NIK</th>
-                <th>Status Kepemilikan</th>
-                <th>Luas Lantai (m²)</th>
-                <th>Jenis Lantai</th>
-                <th>Jenis Dinding</th>
-                <th>Sumber Air Minum</th>
-                <th>Sumber Penerangan</th>
+                <th>NAMA KEPALA KELUARGA</th>
+                <th>JUMLAH ANGGOTA RTM</th>
+                <th>STATUS KEPEMILIKAN</th>
+                <th>LUAS LANTAI (M²)</th>
+                <th>JENIS LANTAI</th>
+                <th>JENIS DINDING</th>
+                <th>SUMBER AIR MINUM</th>
+                <th>SUMBER PENERANGAN</th>
+                <th>BAHAN BAKAR UNTUK MEMASAK</th>
+                <th>TEMPAT PEMBUANGAN AKHIR TINJA</th>
             </tr>
         </thead>
         <tbody></tbody>
@@ -36,7 +40,7 @@
             var filter = str.replace(/&amp;/g, '&')
             const header = @include('layouts.components.header_bearer_api_gabungan');
             $.ajax({
-                url: `{{ config('app.databaseGabunganUrl').'/api/v1/presisi/papan' }}?${filter}`,
+                url: `{{ config('app.databaseGabunganUrl').'/api/v1/data-presisi/papan/rtm' }}?${filter}`,
                 headers: header,
                 method: 'get',
                 success: function(json) {
@@ -46,13 +50,17 @@
                         var row = `
                             <tr>
                                 <td class="padat">${no}</td>
-                                <td>${item.attributes.nik_kepala_rtm || 'N/A'}</td>
+                                <td>${item.attributes.nik || 'N/A'}</td>
+                                <td>${item.attributes.kepala_keluarga || 'N/A'}</td>
+                                <td>${item.attributes.jumlah_anggota || 'N/A'}</td>
                                 <td>${item.attributes.kd_stat_bangunan_tinggal || 'N/A'}</td>
                                 <td>${item.attributes.luas_lantai || 'N/A'}</td>
                                 <td>${item.attributes.kd_jenis_lantai_terluas || 'N/A'}</td>
                                 <td>${item.attributes.kd_jenis_dinding || 'N/A'}</td>
                                 <td>${item.attributes.kd_sumber_air_minum || 'N/A'}</td>
                                 <td>${item.attributes.kd_sumber_penerangan_utama || 'N/A'}</td>
+                                <td>${item.attributes.kd_bahan_bakar_memasak || 'N/A'}</td>
+                                <td>${item.attributes.kd_pembuangan_akhir_tinja || 'N/A'}</td>
                             </tr>
                             `
 

--- a/resources/views/data_pokok/data_presisi/papan/detail.blade.php
+++ b/resources/views/data_pokok/data_presisi/papan/detail.blade.php
@@ -17,7 +17,7 @@
                 <div class="card-header">
                     <div class="row">
                         <div class="col-sm-12 mb-4">
-                            <a href="{{ route('data-pokok.data-presisi-pangan.index') }}" class="btn btn-social btn-info btn-sm visible-xs-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"><i class="fa fa-arrow-circle-left"></i> Kembali Ke Daftar Data Pangan</a>
+                            <a href="{{ route('satu-data.dtks.index') }}" class="btn btn-social btn-info btn-sm visible-xs-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"><i class="fa fa-arrow-circle-left"></i> Kembali Ke Daftar Data Papan</a>
                         </div>
                     </div>
                     <div class="box-body">
@@ -39,16 +39,11 @@
                                         <td>Alamat</td>
                                         <td>:</td>
                                         <td>{{ $data->alamat }}</td>
-                                    </tr>
-                                    <tr>
-                                        <td>Jumalah Anggota</td>
-                                        <td>:</td>
-                                        <td>{{ $data->jumlah_anggota }}</td>
-                                    </tr>
+                                    </tr>                                    
                                     <tr>
                                         <td>Jumlah KK</td>
                                         <td>:</td>
-                                        <td>{{ $data->jumlah_kk }}</td>
+                                        <td>{{ $data->jumlah_kk ?? 0}}</td>
                                     </tr>
                                 </tbody>
                             </table>
@@ -60,30 +55,24 @@
             <div class="card card-outline card-primary">
                 <div class="card-body">
                     <div class="table-responsive">
-                        <table class="table table-striped" id="detail-pangan">
+                        <table class="table table-striped" id="detail-papan">
                             <thead>
                                 <tr>
                                     <th>NO</th>
                                     <th>NIK</th>
                                     <th>NOMOR KK</th>
                                     <th>NAMA</th>
-                                    <th>JENIS LAHAN</th>
-                                    <th>LUAS LAHAN</th>
-                                    <th>LUAS TANAM</th>
-                                    <th>STATUS LAHAN</th>
-                                    <th>KOMODITI UTAMA TANAMAN PANGAN</th>
-                                    <th>KOMODITI TANAMAN PANGAN LAINNYA</th>
-                                    <th>JUMLAH BERDASARKAN JENIS KOMODITI</th>
-                                    <th>USIA KOMODITI</th>
-                                    <th>JENIS PETERNAKAN</th>
-                                    <th>JUMLAH POPULASI</th>
-                                    <th>JENIS PERIKANAN</th>
-                                    <th>FREKWENSI MAKANAN PERHARI</th>
-                                    <th>FREKWENSI KONSUMSI SAYUR PERHARI</th>
-                                    <th>FREKWENSI KONSUMSI BUAH PERHARI</th>
-                                    <th>FREKWENSI KONSUMSI DAGING PERHARI</th>
-                                    <th>LONGITUDE</th>
-                                    <th>LATITUDE</th>
+                                    <th>STATUS KEPEMILIKAN</th>
+                                    <th>LUAS LANTAI (M²)</th>
+                                    <th>JENIS LANTAI</th>
+                                    <th>JENIS DINDING</th>
+                                    <th>SUMBER AIR MINUM</th>
+                                    <th>SUMBER PENERANGAN</th>
+                                    <th>BAHAN BAKAR UNTUK MEMASAK</th>
+                                    <th>TEMPAT PEMBUANGAN AKHIR TINJA</th>
+                                    <th>DAYA TERPASANG</th>
+                                    <th>DAYA TERPASANG 2</th>
+                                    <th>DAYA TERPASANG 3</th>
                                     <th>TANGGAL PENGISIAN</th>
                                     <th>STATUS PENGISIAN</th>
                                 </tr>
@@ -101,9 +90,10 @@
     <script nonce="{{ csp_nonce() }}">
     document.addEventListener("DOMContentLoaded", function(event) {
         const headers = @include('layouts.components.header_bearer_api_gabungan');
-        var url = new URL("{{ config('app.databaseGabunganUrl').'/api/v1/data-presisi/pangan/rtm' }}");
+        var url = new URL("{{ config('app.databaseGabunganUrl').'/api/v1/data-presisi/papan' }}");
         url.searchParams.set("filter[rtm_id]", "{{ $data->rtm_id }}");
-        var pangan = $('#detail-pangan').DataTable({
+        url.searchParams.set("filter[tahun]", "{{ $data->tahun }}");
+        var papan = $('#detail-papan').DataTable({
             processing: true,
             serverSide: true,
             autoWidth: false,
@@ -158,40 +148,81 @@
                     data: 'attributes.nama',
                     orderable: false,
                 },
-                { data: 'attributes.jenis_lahan', orderable: false },
-                { data: 'attributes.luas_lahan', orderable: false },
-                { data: 'attributes.luas_tanam', orderable: false },
-                { data: 'attributes.status_lahan', orderable: false },
-                { data: 'attributes.komoditi_utama_tanaman_pangan', orderable: false },
-                { data: 'attributes.komoditi_tanaman_pangan_lainnya', orderable: false },
-                { data: 'attributes.jumlah_berdasarkan_jenis_komoditi', orderable: false },
-                { data: 'attributes.usia_komoditi', orderable: false },
-                { data: 'attributes.jenis_peternakan', orderable: false },
-                { data: 'attributes.jumlah_populasi', orderable: false },
-                { data: 'attributes.jenis_perikanan', orderable: false },
-                { data: 'attributes.frekwensi_makanan_perhari', orderable: false },
-                { data: 'attributes.frekwensi_konsumsi_sayur_perhari', orderable: false },
-                { data: 'attributes.frekwensi_konsumsi_buah_perhari', orderable: false },
-                { data: 'attributes.frekwensi_konsumsi_daging_perhari', orderable: false },
-                { data: 'attributes.longitude', orderable: false },
-                { data: 'attributes.latitude', orderable: false },
-                { data: 'attributes.tanggal_pengisian', orderable: false },
-                { data: 'attributes.status_pengisian', orderable: false },
+                {
+                    data: "attributes.kd_stat_bangunan_tinggal",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.luas_lantai",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.kd_jenis_lantai_terluas",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.kd_jenis_dinding",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.kd_sumber_air_minum",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.kd_sumber_penerangan_utama",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.kd_bahan_bakar_memasak",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.kd_pembuangan_akhir_tinja",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.kd_daya_terpasang",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.kd_daya_terpasang2",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: "attributes.kd_daya_terpasang3",
+                    defaultContent: 'N/A',
+                    orderable: false,
+                },
+                {
+                    data: 'attributes.tanggal_pengisian',
+                    orderable: false
+                },
+                {
+                    data: 'attributes.status_pengisian',
+                    orderable: false
+                },
             ],
             order: [
                 [10, 'asc']
             ]
         });
-        pangan.on('draw.dt', function() {
-            var PageInfo = $('#detail-pangan').DataTable().page.info();
-            pangan.column(0, {
+        papan.on('draw.dt', function() {
+            var PageInfo = $('#detail-papan').DataTable().page.info();
+            papan.column(0, {
                 page: 'current'
             }).nodes().each(function(cell, i) {
                 cell.innerHTML = i + 1 + PageInfo.start;
             });
-        });
-        $('#sex, #dusun, #rw, #rt').change(function() {
-            pangan.draw();
         });
     });
     </script>

--- a/resources/views/dtks/papan/chart.blade.php
+++ b/resources/views/dtks/papan/chart.blade.php
@@ -1,0 +1,103 @@
+<script nonce="{{ csp_nonce() }}"  >
+    function grafikPie() {
+        data = [];
+        $('#barChart').remove();
+        $('#donutChart').remove();
+        $('#grafik').append(
+            '<canvas id="barChart"></canvas>'
+        );
+        $('#pie').append(
+            '<canvas id="donutChart"></canvas>'
+        );
+
+        // Data untuk bar chart        
+        tampilChart('bar', 'barChart', generateChartData(data_grafik, 'kd_stat_bangunan_tinggal', 'Status Kepemilikan'));
+
+    }
+
+    function tampilChart(type, canvasId, chartData, chartOptions = {}) {
+        var chartCanvas = $(`#${canvasId}`).get(0).getContext('2d');
+
+        // Konfigurasi opsi default untuk chart
+        var defaultOptions = {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: {
+                    display: true,
+                    position: 'top',
+                },
+                tooltip: {
+                    enabled: true,
+                },
+            },
+        };
+
+        // Gabungkan opsi default dengan opsi spesifik yang diberikan
+        var options = { ...defaultOptions, ...chartOptions };
+
+        // Membuat chart baru
+        new Chart(chartCanvas, {
+            type: type, // Tipe chart (bar, doughnut, dll.)
+            data: {
+                labels: chartData.labels, // Menggunakan labels dari data
+                datasets: chartData.datasets, // Menggunakan datasets dari data
+            },
+            options: options,
+        });
+    }
+
+
+    function generateChartData(data, key, label = 'Jumlah Anggota') {
+        var labelCounts = {}; // Objek untuk menghitung jumlah label unik
+        var labels = [];
+        var counts = [];
+        var backgroundColors = [];
+
+        // Hitung jumlah label unik berdasarkan kunci yang diberikan
+        data.forEach(function (item) {
+            var value = item[key]; // Ambil nilai berdasarkan kunci
+            if (!labelCounts[value]) {
+                labelCounts[value] = 0;
+            }
+            labelCounts[value]++;
+        });
+
+        // Buat data untuk chart
+        Object.keys(labelCounts).forEach(function (label) {
+            let color = randColorRGB();
+            labels.push(label); // Tambahkan label
+            counts.push(labelCounts[label]); // Tambahkan jumlah
+            backgroundColors.push(color); // Tambahkan warna
+        });
+
+        // Struktur data chart
+        return {
+            labels: labels,
+            datasets: [
+                {
+                    label: label,
+                    data: counts,
+                    backgroundColor: backgroundColors,
+                },
+            ],
+        };
+    }
+
+</script>
+@push('css')
+    <style nonce="{{ csp_nonce() }}" >
+        #barChart {
+            min-height: 250px;
+            height: 250px;
+            max-height: 250px;
+            max-width: 100%;
+        }
+        #donutChart {
+            min-height: 250px;
+            height: 250px;
+            max-height: 250px;
+            max-width: 100%;
+        }
+    </style>
+@endpush

--- a/resources/views/dtks/papan/index.blade.php
+++ b/resources/views/dtks/papan/index.blade.php
@@ -28,22 +28,11 @@
             <div class="card card-outline card-primary">
                 <div class="card-header">
                     <div class="row">
-                        <div class="col-sm-2">
-                            <select id="filter-tahun" class="form-control form-control-sm">
-                                @php
-                                    $currentYear = date('Y');
-                                    $startYear = 2020;
-                                @endphp
-                                @for($year = $currentYear; $year >= $startYear; $year--)
-                                    <option value="{{ $year }}" {{ $year == $currentYear ? 'selected' : '' }}>{{ $year }}</option>
-                                @endfor
-                            </select>
+                        <x-filter-tahun />
+                        <div class="col-auto">
+                            <x-print-button :print-url="url('data-presisi/papan/cetak')" table-id="table-dtks" :filter="[]" />
                         </div>
-                        <div class="col-sm-3">
-                            <button id="cetak" type="button" class="btn btn-primary btn-sm" data-url="">
-                                <i class="fa fa-print"></i> Cetak
-                            </button>
-                        </div>
+                        <x-excel-download-button :download-url="config('app.databaseGabunganUrl') . '/api/v1/data-presisi/papan/rtm/download'" table-id="table-dtks" filename="data_presisi_papan" />
                     </div>
                 </div>
                 <div class="card-body">
@@ -51,8 +40,11 @@
                         <table class="table table-striped" id="table-dtks">
                             <thead>
                                 <tr>
+                                    <th>Aksi</th>
                                     <th>#</th>
                                     <th>NIK</th>
+                                    <th>Nama Kepala Keluarga</th>
+                                    <th>Jumlah Anggota RTM</th>
                                     <th>Status Kepemilikan</th>
                                     <th>Luas Lantai (m²)</th>
                                     <th>Jenis Lantai</th>
@@ -71,7 +63,7 @@
 @endsection
 
 @section('js')
-    @include('data_pokok.ketenagakerjaan.chart')
+    @include('dtks.papan.chart')
     <script nonce="{{ csp_nonce() }}">
         let data_grafik = [];
         document.addEventListener("DOMContentLoaded", function(event) {
@@ -86,7 +78,7 @@
                     columns: [0]
                 },
                 ajax: {
-                    url: `{{ config('app.databaseGabunganUrl').'/api/v1/presisi/papan' }}`,
+                    url: `{{ config('app.databaseGabunganUrl').'/api/v1/data-presisi/papan/rtm' }}`,
                     headers: header,  
                     method: 'get',
                     data: function(row) {
@@ -99,23 +91,17 @@
                             "filter[tahun]": $('#filter-tahun').val(),
                         };
                     },
-                    dataSrc: function(json) {
-                        json.recordsTotal = json.meta.pagination.total
-                        json.recordsFiltered = json.meta.pagination.total
+                    dataSrc: function(json) {                   
 
-                        // Extract chart data from API response
-                        data_grafik = json.data.filter(item => item.attributes.kd_stat_bangunan_tinggal)
-                            .map(item => ({
-                                label: item.attributes.kd_stat_bangunan_tinggal,
-                                value: 1 // Count each occurrence (can aggregate here)
-                            }));
+                        json.recordsTotal = json.meta?.pagination?.total || 0;
+                        json.recordsFiltered = json.meta?.pagination?.total || 0;
 
-                        // Combine duplicate labels and aggregate values
-                        //data_grafik = combineData(data_grafik);
-                            
-                        tampilChart('bar', 'barChart', generateChartData(data_grafik, 'label', 'Statistik Papan'));
+                        if (json.data && json.data.length > 0) {
+                            data_grafik = json.data.map(item => item.attributes);
+                            grafikPie();
+                        }
 
-                        return json.data
+                        return json.data || [];
                     },
                 },
                 columnDefs: [{
@@ -128,7 +114,31 @@
                         searchable: false,
                     },
                 ],
-                columns: [
+                columns: [{
+                        data: function(data) {
+
+                            let d = data.attributes
+                            let obj = {
+                                'rtm_id': data.id,
+                                'no_kartu_rumah': d.no_kk,
+                                'nama_kepala_keluarga': d.kepala_keluarga,
+                                'alamat': d.alamat,
+                                'jumlah_anggota': d.jumlah_anggota,
+                                'jumlah_kk': d.jumlah_kk,
+                                'tahun': d.tahun ?? $('#filter-tahun').val()
+                            }
+
+                            let jsonData = encodeURIComponent(JSON.stringify(obj));
+
+                            const _url = "{{ route('data-pokok.data-presisi-papan.detail_datasandang', ['data' => '__DATA__']) }}".replace('__DATA__', jsonData)
+
+                            return `<a href="${_url}" title="Detail" data-button="Detail">
+                                    <button type="button" class="btn btn-info btn-sm">Detail</button>
+                                </a>`;
+                        },
+                        searchable: false,
+                        orderable: false
+                    },
                     {
                         "className": 'details-control',
                         "orderable": false,
@@ -136,10 +146,14 @@
                         "defaultContent": ''
                     },
                     {
-                        data: "attributes.nik_kepala_rtm",
-                        name: "rtm.kepalaKeluarga.nik",
+                        data: "attributes.nik",
                         orderable: false,
-                        render: (data) => data || 'N/A',
+                    },
+                    {
+                        data: "attributes.kepala_keluarga",
+                    },
+                    {
+                        data: "attributes.jumlah_anggota",
                     },
                     {
                         data: "attributes.kd_stat_bangunan_tinggal",
@@ -191,7 +205,7 @@
                     <table class="table table-striped">
                         <tr>
                             <td><strong>NIK Kepala RTM:</strong></td>
-                            <td>${data.attributes.nik_kepala_rtm || 'N/A'}</td>
+                            <td>${data.attributes.nik || 'N/A'}</td>
                         </tr>
                         <tr>
                             <td><strong>Status Kepemilikan:</strong></td>
@@ -232,15 +246,8 @@
             $('#filter-tahun').on('change', function() {
                 dtks.ajax.reload();
                 data_grafik = [];
-                tampilChart('bar', 'barChart', generateChartData(data_grafik, 'label', 'Statistik Papan'));
-            });
-
-            $('#cetak').on('click', function() {
-                let baseUrl = "{{ url('satu-data/dtks/cetak') }}";
-                let params = dtks.ajax.params(); // Get DataTables params
-                let queryString = new URLSearchParams(params).toString(); // Convert params to query string
-                window.open(`${baseUrl}?${queryString}`, '_blank'); // Open the URL with appended query
-            });
+                grafikPie();
+            });            
 
             // Combine data by aggregating values for duplicate labels
             function combineData(data) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -348,6 +348,8 @@ Route::middleware(['auth', 'teams_permission', 'password.expiry', 'password.weak
         
         Route::prefix('papan')->group(function () {            
             Route::get('detail_data', [App\Http\Controllers\DataPresisiPapanController::class, 'detailData'])->name('data-pokok.data-presisi-papan.detail_data');            
+            Route::get('detail', [App\Http\Controllers\DataPresisiPapanController::class, 'detail'])->name('data-pokok.data-presisi-papan.detail_datasandang');
+            Route::get('cetak', [App\Http\Controllers\DataPresisiPapanController::class, 'cetak'])->name('data-pokok.data-presisi-papan.cetak');
         })
             ->middleware(['permission:datapresisi-papan-read']);
 


### PR DESCRIPTION
# PR #1047 - Tambahkan fitur export excel di menu data presisi -> Papan

## Deskripsi Singkat

Menambahkan fitur export Excel dan cetak pada menu Data Presisi -> Papan, menyelaraskan fungsionalitas dengan menu Data Presisi lainnya (Pangan, Sandang, dll) yang sudah memiliki fitur tersebut. Selain itu, dilakukan perbaikan data yang ditampilkan agar lengkap dan sesuai, termasuk kolom detail yang sebelumnya hanya tersedia pada expand row di tabel utama.

## Depedency PR
https://github.com/OpenSID/API-Database-Gabungan/pull/412

**Related Issue:** https://github.com/OpenSID/OpenKab/issues/1047

## Perubahan yang Dilakukan

### 1. `app/Http/Controllers/DataPresisiPapanController.php`
- **Penambahan method `cetak()`** — menangani request cetak/halaman print, merender view `data_pokok.data_presisi.papan.cetak` dengan parameter filter query string.
- **Penambahan method `detail()`** — menangani request halaman detail RTM, decode data JSON dari request parameter dan merender view `data_pokok.data_presisi.papan.detail`.

### 2. `routes/web.php`
- **Penambahan 2 route baru** pada group prefix `papan`:
  - `GET detail` → `DataPresisiPapanController::detail` dengan nama route `data-pokok.data-presisi-papan.detail_datasandang`
  - `GET cetak` → `DataPresisiPapanController::cetak` dengan nama route `data-pokok.data-presisi-papan.cetak`

### 3. `resources/views/dtks/papan/index.blade.php` (refactor)
- **Filter tahun** — diganti dari hardcoded `<select>` menjadi komponen Blade `<x-filter-tahun />` untuk konsistensi.
- **Tombol cetak** — diganti dari manual jQuery click handler ke komponen `<x-print-button>` dengan URL cetak yang benar (`data-presisi/papan/cetak`).
- **Tombol export Excel** — ditambahkan komponen `<x-excel-download-button>` dengan endpoint download API `/api/v1/data-presisi/papan/rtm/download`.
- **Kolom tabel ditambahkan** — menambah kolom "Aksi" (Detail button), "Nama Kepala Keluarga", dan "Jumlah Anggota RTM" yang sebelumnya tidak ada.
- **Detail button** — kolom Aksi menampilkan tombol Detail yang mengarah ke route `data-pokok.data-presisi-papan.detail_datasandang` dengan encoded JSON data (rtm_id, no_kartu_rumah, nama_kepala_keluarga, alamat, jumlah_anggota, jumlah_kk, tahun).
- **API endpoint** — diubah dari `/api/v1/presisi/papan` ke `/api/v1/data-presisi/papan/rtm` (konsisten dengan API data presisi lainnya).
- **Data mapping** — diubah `nik_kepala_rtm` ke `nik`, ditambahkan `kepala_keluarga` dan `jumlah_anggota`.
- **Format detail row** — `nik_kepala_rtm` diubah ke `nik`.
- **Chart** — referensi chart diubah dari `data_pokok.ketenagakerjaan.chart` ke `dtks.papan.chart`; rendering chart di-refactor untuk menggunakan `grafikPie()` dengan data yang di-map dari `attributes` langsung.
- **RecordsTotal/Filtered** — ditambahkan fallback `|| 0` dan `|| []` untuk handling response kosong dari API.
- **Tahun filter** — menambahkan `tahun` property ke obj detail button dari `d.tahun ?? $('#filter-tahun').val()`.
- **Cetak handler jQuery** — dihapus (diganti komponen Blade `<x-print-button>`).

### 4. `resources/views/dtks/papan/chart.blade.php` (file baru)
- **Chart script baru** — berisi fungsi `grafikPie()` yang menampilkan bar chart Status Kepemilikan (`kd_stat_bangunan_tinggal`) dari data papan.
- **Fungsi helper** — `tampilChart()` untuk rendering chart Chart.js, `generateChartData()` untuk agregasi data berdasarkan key dan label.
- **CSS** — styling untuk `#barChart` dan `#donutChart` dengan fixed height 250px.

### 5. `resources/views/data_pokok/data_presisi/papan/cetak.blade.php` (dipindahkan & diperbaiki)
- **File dipindahkan** — dari `resources/views/dtks/papan/cetak.blade.php` ke `resources/views/data_pokok/data_presisi/papan/cetak.blade.php` (konsisten dengan struktur view data presisi lainnya).
- **Header uppercase** — semua header tabel diubah ke huruf besar (NO, NIK, NAMA KEPALA KELUARGA, dll).
- **Kolom ditambahkan** — ditambah kolom NAMA KEPALA KELUARGA, JUMLAH ANGGOTA RTM, BAHAN BAKAR UNTUK MEMASAK, TEMPAT PEMBUANGAN AKHIR TINJA (sebelumnya hanya 8 kolom, sekarang 12).
- **API endpoint** — diubah dari `/api/v1/presisi/papan` ke `/api/v1/data-presisi/papan/rtm`.
- **Data mapping diperbaiki** — `nik_kepala_rtm` diubah ke `nik`, ditambahkan mapping `kepala_keluarga`, `jumlah_anggota`, `kd_bahan_bakar_memasak`, `kd_pembuangan_akhir_tinja`.

### 6. `resources/views/data_pokok/data_presisi/papan/detail.blade.php` (file baru)
- **Halaman detail RTM** — menampilkan Rincian Suplemen (No KRT, Kepala RT, Alamat, Jumlah KK) dan tabel DataTables anggota RTM dengan 17 kolom lengkap:
  - NO, NIK, NOMOR KK, NAMA, STATUS KEPEMILIKAN, LUAS LANTAI, JENIS LANTAI, JENIS DINDING, SUMBER AIR MINUM, SUMBER PENERANGAN, BAHAN BAKAR UNTUK MEMASAK, TEMPAT PEMBUANGAN AKHIR TINJA, DAYA TERPASANG, DAYA TERPASANG 2, DAYA TERPASANG 3, TANGGAL PENGISIAN, STATUS PENGISIAN
- **API endpoint** — menggunakan `/api/v1/data-presisi/papan` dengan filter `rtm_id` dan `tahun`.
- **Tombol kembali** — mengarah ke route `data-pokok.data-presisi-papan.index` (sebelumnya file ini menggunakan data pangan yang salah).

### 7. `resources/views/data_pokok/data_presisi/pangan/detail.blade.php` (bug fix)
- **API URL diperbaiki** — diubah dari `/api/v1/data-presisi/pangan` ke `/api/v1/data-presisi/pangan/rtm` untuk konsistensi endpoint API.

## Alasan Perubahan

1. **Fitur export Excel belum ada** — menu Data Presisi Papan tidak memiliki tombol download Excel dan cetak, sedangkan menu Pangan dan Sandang sudah memiliki fitur ini (issue #1047).
2. **Data tidak lengkap** — tabel papan sebelumnya hanya menampilkan 8 kolom tanpa Nama Kepala Keluarga, Jumlah Anggota RTM, dan kolom detail (Bahan Bakar Memasak, Pembuangan Tinja). Data detail hanya tersedia melalui expand row, tidak tercetak.
3. **API endpoint tidak konsisten** — menggunakan `/api/v1/presisi/papan` bukan `/api/v1/data-presisi/papan/rtm` seperti data presisi lainnya.
4. **View cetak lokasi salah** — berada di `dtks/papan/` bukan `data_pokok/data_presisi/papan/`.
5. **Detail page tidak ada** — tidak ada halaman detail RTM untuk papan, tombol Detail di index mengarah ke route sandang.
6. **Chart referensi salah** — menggunakan chart ketenagakerjaan bukan chart papan.
7. **Komponen Blade** — filter tahun dan tombol cetak menggunakan hardcoded HTML, bukan komponen Blade yang sudah ada (`<x-filter-tahun>`, `<x-print-button>`, `<x-excel-download-button>`).

## Dampak Perubahan

- **Positif:** Menu Data Presisi Papan sekarang memiliki fitur export Excel, cetak, dan halaman detail yang konsisten dengan menu Pangan dan Sandang. Data yang ditampilkan lebih lengkap termasuk kolom detail.
- **Potensi risiko:** Perubahan API endpoint dari `/presisi/papan` ke `/data-presisi/papan/rtm` harus dipastikan endpoint baru sudah tersedia di API gabungan. Route baru `detail_datasandang` untuk papan perlu dipastikan middleware permission sudah sesuai.

## Steps to Reproduce (Sebelum Fix)

1. Buka menu Data Presisi -> Papan
2. Tidak ada tombol download Excel
3. Tombol cetak menggunakan handler jQuery manual, bukan komponen Blade
4. Klik expand row untuk melihat detail — data Bahan Bakar Memasak dan Pembuangan Tinja hanya tersedia di expand, tidak tercetak
5. Tidak ada halaman detail RTM (tombol Detail mengarah ke route sandang)

## Testing Checklist

- [ ] Halaman Data Presisi Papan menampilkan tombol Download Excel
- [ ] Klik Download Excel menghasilkan file Excel dengan data yang benar (semua 12 kolom termasuk Bahan Bakar Memasak dan Pembuangan Tinja)
- [ ] Tombol Cetak membuka halaman cetak dengan data lengkap (12 kolom, header uppercase)
- [ ] Tombol Detail pada setiap baris mengarah ke halaman detail RTM papan (bukan sandang)
- [ ] Halaman detail RTM menampilkan Rincian Suplemen dan tabel 17 kolom anggota RTM
- [ ] Filter tahun berfungsi dengan benar (menggunakan komponen `<x-filter-tahun>`)
- [ ] Chart/grafik bar Status Kepemilikan tampil dan berubah sesuai filter tahun
- [ ] API endpoint `/api/v1/data-presisi/papan/rtm` mengembalikan data yang benar
- [ ] API endpoint `/api/v1/data-presisi/papan/rtm/download` berfungsi untuk download Excel
- [ ] Permission middleware `datapresisi-papan-read` berfungsi untuk route baru (detail, cetak)
- [ ] Data Pangan detail tidak terdampak (API URL fix `/pangan/rtm` masih berfungsi)