### PR TITLE
Fix: perbaikan suplemen detail dan edit

### DIFF
--- a/app/Http/Controllers/SuplemenController.php
+++ b/app/Http/Controllers/SuplemenController.php
@@ -2,10 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Config;
-use App\Models\Suplemen;
-use App\Models\SuplemenTerdata;
-use App\Models\Wilayah;
+use App\Services\SuplemenService;
 use OpenSpout\Common\Entity\Row;
 use OpenSpout\Common\Entity\Style\Border;
 use OpenSpout\Common\Entity\Style\BorderPart;
@@ -15,6 +12,13 @@ use OpenSpout\Writer\XLSX\Writer;
 
 class SuplemenController extends Controller
 {
+    protected SuplemenService $service;
+
+    public function __construct(SuplemenService $service)
+    {
+        $this->service = $service;
+    }
+
     public function index()
     {
         $list_sasaran = unserialize(SASARAN);
@@ -30,8 +34,8 @@ class SuplemenController extends Controller
         if ($id) {
             $action = 'Ubah';
             $form_action = '/api/v1/suplemen/update/'.$id;
-            $suplemen = Suplemen::with('terdata')->findOrFail($id);
-
+            $suplemen = $this->service->suplemenById($id);
+            
             return view('suplemen.edit', compact('list_sasaran', 'attributes', 'action', 'form_action', 'suplemen'));
         } else {
             $action = 'Tambah';
@@ -45,42 +49,37 @@ class SuplemenController extends Controller
     public function detail($id)
     {
         $sasaran = unserialize(SASARAN);
-        $suplemen = Suplemen::findOrFail($id);
-        $wilayah = Wilayah::treeAccess();
+        $suplemen = $this->service->suplemenById($id);
 
-        return view('suplemen.detail', compact('id', 'sasaran', 'suplemen', 'wilayah'));
+        return view('suplemen.detail', compact('id', 'sasaran', 'suplemen'));
     }
 
     public function ekspor($id = 0)
     {
-        $data_suplemen['suplemen'] = Suplemen::findOrFail($id)->toArray();
-        $data_suplemen['terdata'] = SuplemenTerdata::anggota($data_suplemen['suplemen']['sasaran'], $id)->get()->toArray();
+        $suplemen = $this->service->suplemenById($id);
+        if (! $suplemen) {
+            abort(404);
+        }
 
-    // Ambil form_isian dari suplemen dan dekode
-        $formIsian = json_decode($data_suplemen['suplemen']['form_isian'], true); // pastikan form_isian didecode menjadi array
+        $data_suplemen['suplemen'] = (array) $suplemen;
+        $data_suplemen['terdata'] = $this->service->terdata($suplemen->sasaran, $id)->toArray();
 
-        // Nama file untuk ekspor
-        $file_name = $data_suplemen['suplemen']['nama'].'_'.date('d_m_Y').'.xlsx';
+        $formIsian = is_array($suplemen->form_isian) ? $suplemen->form_isian : json_decode($suplemen->form_isian, true);
 
-        // Path untuk menyimpan file
+        $file_name = $suplemen->nama.'_'.date('d_m_Y').'.xlsx';
         $file_path = storage_path('app/exports/'.$file_name);
 
-        // Pastikan folder 'exports' ada
         $exportDir = storage_path('app/exports');
         if (! file_exists($exportDir)) {
-            // Buat folder 'exports' jika belum ada
             mkdir($exportDir, 0775, true);
         }
 
-        // Buat instance writer
-        $writer = new Writer();
-        $writer->openToFile($file_path); // Gunakan openToFile daripada openToBrowser untuk menyimpan di server
+        $writer = new Writer;
+        $writer->openToFile($file_path);
 
-        // Ubah Nama Sheet
         $sheet = $writer->getCurrentSheet();
         $sheet->setName('Peserta');
 
-        // Deklarasi Style
         $border = new Border(
             new BorderPart(Border::TOP, Color::GREEN, Border::WIDTH_THIN, Border::STYLE_SOLID),
             new BorderPart(Border::BOTTOM, Color::GREEN, Border::WIDTH_THIN, Border::STYLE_SOLID),
@@ -88,28 +87,25 @@ class SuplemenController extends Controller
             new BorderPart(Border::RIGHT, Color::GREEN, Border::WIDTH_THIN, Border::STYLE_SOLID)
         );
 
-        $headerStyle = (new Style())
+        $headerStyle = (new Style)
             ->setBorder($border)
             ->setBackgroundColor(Color::YELLOW)
             ->setFontBold();
 
-        $footerStyle = (new Style())
+        $footerStyle = (new Style)
             ->setBackgroundColor(Color::LIGHT_GREEN);
 
-        // Cetak Header Tabel
         $values = ['Peserta', 'Nama', 'Tempat Lahir', 'Tanggal Lahir', 'Alamat', 'Keterangan'];
 
-        // Ambil header dinamis berdasarkan label_kode dari form_isian
         if ($formIsian) {
             foreach ($formIsian as $field) {
-                $values[] = $field['label_kode']; // Tambahkan label_kode sebagai header
+                $values[] = $field['label_kode'];
             }
         }
 
         $rowFromValues = Row::fromValues($values, $headerStyle);
         $writer->addRow($rowFromValues);
 
-        // Cetak Data Anggota Suplemen
         $data_anggota = $data_suplemen['terdata'];
 
         foreach ($data_anggota as $data) {
@@ -122,13 +118,12 @@ class SuplemenController extends Controller
                 empty($data['keterangan']) ? '-' : $data['keterangan'],
             ];
 
-        // Tambahkan data dari data_form_isian sesuai dengan form_isian
-            $dataFormIsian = json_decode($data['data_form_isian'], true); // Dekode data_form_isian
+            $dataFormIsian = is_array($data['data_form_isian']) ? $data['data_form_isian'] : json_decode($data['data_form_isian'], true);
 
             if ($formIsian) {
                 foreach ($formIsian as $field) {
-                    $kode = $field['nama_kode']; // Ambil nama_kode dari form_isian
-                    $cells[] = isset($dataFormIsian[$kode]) ? $dataFormIsian[$kode] : 'Tidak Ada Data'; // Tambahkan nilai sesuai nama_kode
+                    $kode = $field['nama_kode'];
+                    $cells[] = isset($dataFormIsian[$kode]) ? $dataFormIsian[$kode] : 'Tidak Ada Data';
                 }
             }
 
@@ -136,14 +131,12 @@ class SuplemenController extends Controller
             $writer->addRow($singleRow);
         }
 
-        // Tambahkan Baris Kosong
         $cells = [
             '###', '', '', '', '', '',
         ];
         $singleRow = Row::fromValues($cells);
         $writer->addRow($singleRow);
 
-        // Cetak Catatan
         $array_catatan = [
             [
                 'Catatan:', '', '', '', '', '',
@@ -169,26 +162,30 @@ class SuplemenController extends Controller
         }
         $writer->addRows($rows_catatan);
 
-        // Tutup Writer
         $writer->close();
 
-        // Mengirim file ke browser jika perlu
         return response()->download($file_path);
     }
 
     public function daftar($id = 0, $aksi = '')
     {
         if ($id > 0) {
-            $data['suplemen'] = Suplemen::findOrFail($id)->toArray();
-            $data['terdata'] = SuplemenTerdata::anggota($data['suplemen']['sasaran'], $data['suplemen']['id'])->get()->toArray();
-            $data['sasaran'] = unserialize(SASARAN);
-            $suplemenTerdata = SuplemenTerdata::anggota($data['suplemen']['sasaran'], $data['suplemen']['id'])->first();
+            $suplemen = $this->service->suplemenById($id);
+            if (! $suplemen) {
+                abort(404);
+            }
 
-            if ($suplemenTerdata) {
-                $wilayah = Config::where('id', $suplemenTerdata->config_id)->first() ?? '';
-                $data['nama_desa'] = $wilayah->nama_desa ?? '';
-                $data['nama_kecamatan'] = $wilayah->nama_kecamatan ?? '';
-                $data['nama_kabupaten'] = $wilayah->nama_kabupaten ?? '';
+            $data['suplemen'] = (array) $suplemen;
+            $data['terdata'] = $this->service->terdata($suplemen->sasaran, $id)->toArray();
+            $data['sasaran'] = unserialize(SASARAN);
+
+            $terdataPertama = $this->service->terdata($suplemen->sasaran, $id)->first();
+
+            if ($terdataPertama && ! empty($terdataPertama->config_id)) {
+                $config = $this->service->configDesa(['filter[id]' => $terdataPertama->config_id])->first();
+                $data['nama_desa'] = $config->nama_desa ?? '';
+                $data['nama_kecamatan'] = $config->nama_kecamatan ?? '';
+                $data['nama_kabupaten'] = $config->nama_kabupaten ?? '';
             } else {
                 $data['nama_desa'] = '';
                 $data['nama_kecamatan'] = '';
@@ -197,7 +194,6 @@ class SuplemenController extends Controller
 
             $data['aksi'] = $aksi;
 
-            //pengaturan data untuk format cetak/ unduh
             $data['file'] = 'Laporan Suplemen '.$data['suplemen']['nama'];
             $data['isi'] = 'suplemen.cetak';
             $data['letak_ttd'] = ['2', '2', '3'];

--- a/app/Services/SuplemenService.php
+++ b/app/Services/SuplemenService.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+
+class SuplemenService extends BaseApiService
+{
+    protected int $cacheTtl = 3600;
+
+    public function suplemen(array $filters = [])
+    {
+        $cacheKey = $this->buildCacheKey('suplemen', $filters);
+
+        return Cache::remember($cacheKey, $this->cacheTtl, function () use ($filters) {
+            $data = $this->apiRequest('/api/v1/suplemen', $filters);
+            if (! $data) {
+                return collect([]);
+            }
+
+            return collect($data)->map(fn ($item) => (object) ($item['attributes'] ?? $item));
+        });
+    }
+
+    public function suplemenById($id)
+    {
+        $data = $this->apiRequest('/api/v1/suplemen', ['filter[id]' => $id]);
+        if (! $data) {
+            return null;
+        }
+
+        return (object) ($data[0]['attributes'] ?? $data[0] ?? null);
+    }
+
+    public function terdata($sasaran, $suplemenId, array $filters = [])
+    {
+        $params = array_merge(['page[size]' => 9999], $filters);
+        $cacheKey = $this->buildCacheKey("suplemen_terdata_{$sasaran}_{$suplemenId}", $params);
+
+        return Cache::remember($cacheKey, $this->cacheTtl, function () use ($sasaran, $suplemenId, $params) {
+            $data = $this->apiRequest("/api/v1/suplemen/terdata/{$sasaran}/{$suplemenId}", $params);
+            if (! $data) {
+                return collect([]);
+            }
+
+            return collect($data)->map(fn ($item) => (object) ($item['attributes'] ?? $item));
+        });
+    }
+
+    public function configDesa(array $filters = [])
+    {
+        $cacheKey = $this->buildCacheKey('suplemen_config_desa', $filters);
+
+        return Cache::remember($cacheKey, $this->cacheTtl, function () use ($filters) {
+            $data = $this->apiRequest('/api/v1/config/desa', $filters);
+            if (! $data) {
+                return collect([]);
+            }
+
+            return collect($data)->map(fn ($item) => (object) ($item['attributes'] ?? $item));
+        });
+    }
+
+    public function clearSuplemenCache($id = null)
+    {
+        if ($id) {
+            $this->clearCache('suplemen', ['filter[id]' => $id]);
+        } else {
+            cache()->forget('suplemen');
+        }
+    }
+}

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -9,6 +9,7 @@ Di rilis ini, versi 2607.0.0 berisi penambahan dan perbaikan yang diminta penggu
 1. [#1066](https://github.com/OpenSID/OpenKab/issues/1066) Perbaikan Field tampil ganda saat tambah/edit data pejabat daerah
 2. [#1076](https://github.com/OpenSID/OpenKab/issues/1076) Perbaikan bug dan fitur data presisi
 3. [#1079](https://github.com/OpenSID/OpenKab/issues/1079) Perbaikan Fitur bantuan tidak ada inputan penerima ketika sasaran keluarga, inputan publikasi juga belum ada
+4. [#1078](https://github.com/OpenSID/OpenKab/issues/1078) Perbaikan error ketika membuka detail suplemen, termasuk fitur edit suplemen
 
 
 #### Perubahan Teknis

--- a/resources/views/suplemen/cetak/data_suplemen.blade.php
+++ b/resources/views/suplemen/cetak/data_suplemen.blade.php
@@ -5,7 +5,7 @@
 </tr>
 <tr>
     <td>
-        <strong>Sasaran Suplemen : </strong>{{ $sasaran[$suplemen['sasaran']] }}<br>
+        <strong>Sasaran Suplemen : </strong>{{ $suplemen['sasaran'] }}<br>
         <strong>Keterangan : </strong>{{ $suplemen['keterangan'] }}
     </td>
 </tr>

--- a/resources/views/suplemen/cetak/table.blade.php
+++ b/resources/views/suplemen/cetak/table.blade.php
@@ -1,8 +1,8 @@
 <tr class="border thick">
     <th class="padat">No</th>
-    <th>{{ $suplemen['sasaran'] == 1 ? 'No.' : 'NIK' }} KK</th>
-    <th>{{ $suplemen['sasaran'] == 1 ? 'NIK Penduduk' : 'No. KK' }}</th>
-    <th>{{ $suplemen['sasaran'] == 1 ? 'Nama Penduduk' : 'Kepala Keluarga' }}</th>
+    <th>{{ $suplemen['sasaran'] === 'Penduduk' ? 'No.' : 'NIK' }} KK</th>
+    <th>{{ $suplemen['sasaran'] === 'Penduduk' ? 'NIK Penduduk' : 'No. KK' }}</th>
+    <th>{{ $suplemen['sasaran'] === 'Penduduk' ? 'Nama Penduduk' : 'Kepala Keluarga' }}</th>
     <th>Tempat Lahir</th>
     <th>Tanggal Lahir</th>
     <th>Jenis Kelamin</th>

--- a/resources/views/suplemen/edit.blade.php
+++ b/resources/views/suplemen/edit.blade.php
@@ -39,7 +39,7 @@
                                     <option value="">Pilih Sasaran</option>
                                     @foreach ($list_sasaran as $key => $sasaran)
                                         @if (in_array($key, ['1', '2']))
-                                            <option value="{{ $key }}" {{ selected($key, $suplemen->sasaran) }}>{{ $sasaran }}</option>
+                                            <option value="{{ $key }}" {{ $key == $suplemen->sasaran_id ? 'selected' : '' }}>{{ $sasaran }}</option>
                                         @endif
                                     @endforeach
                                 </select>
@@ -62,8 +62,8 @@
                             <div class="col-sm-9">
                                 <select class="form-control form-control-sm required" required name="status">
                                     <option value="">Pilih Status</option>
-                                    <option value="1" {{ selected(1, $suplemen->status) }}>Aktif</option>
-                                    <option value="0" {{ selected(0, $suplemen->status) }}>Tidak Aktif</option>
+                                    <option value="1" {{ $suplemen->status_id == 1 ? 'selected' : '' }}>Aktif</option>
+                                    <option value="0" {{ $suplemen->status_id == 0 ? 'selected' : '' }}>Tidak Aktif</option>
                                 </select>
                             </div>
                         </div>

--- a/resources/views/suplemen/js/data_suplemen_terdata.blade.php
+++ b/resources/views/suplemen/js/data_suplemen_terdata.blade.php
@@ -1,4 +1,4 @@
-var url = new URL("{{ config('app.databaseGabunganUrl').'/api/v1/suplemen/terdata/'.$suplemen->sasaran.'/'.$suplemen->id }}");
+var url = new URL("{{ config('app.databaseGabunganUrl').'/api/v1/suplemen/terdata/'.$suplemen->sasaran_id.'/'.$suplemen->id }}");
 var suplemen = $('#suplemen').DataTable({
     processing: true,
     serverSide: true,

--- a/resources/views/suplemen/preview_js.blade.php
+++ b/resources/views/suplemen/preview_js.blade.php
@@ -20,19 +20,18 @@
             // Ambil nilai dari form
 
             // Ambil data dari PHP
-            const sasaranMap = JSON.parse('<?php echo json_encode(unserialize(SASARAN)); ?>');
 
             // Ambil value yang dipilih dari dropdown
             const selectedValue = document.querySelector('select[name="sasaran"]').value;
 
             // Ambil nama sasaran berdasarkan value
-            const sasaran = sasaranMap[selectedValue] || 'Belum dipilih';
+            const sasaran = selectedValue || 'Belum dipilih';
             const nama = document.querySelector('input[name="nama"]').value || 'Belum diisi';
             const keterangan = document.querySelector('textarea[name="keterangan"]').value || 'Belum diisi';
             const status = document.querySelector('select[name="status"]').value || 'Belum dipilih';
 
             // Format status
-            const statusText = status === '1' ? 'Aktif' : status === '0' ? 'Tidak Aktif' : 'Belum dipilih';
+            const statusText = status || 'Belum dipilih';
 
             // Ambil data kode isian
             const kodeIsianRows = document.querySelectorAll('#dragable-form-utama tr');

--- a/resources/views/suplemen/rincian.blade.php
+++ b/resources/views/suplemen/rincian.blade.php
@@ -11,7 +11,7 @@
                 <tr>
                     <td>Sasaran Terdata</td>
                     <td>:</td>
-                    <td>{{ $sasaran[$suplemen->sasaran] }}</td>
+                    <td>{{ $suplemen->sasaran }}</td>
                 </tr>
                 <tr>
                     <td>Keterangan</td>

--- a/resources/views/suplemen/table_terdata.blade.php
+++ b/resources/views/suplemen/table_terdata.blade.php
@@ -7,9 +7,9 @@
                     <input type="checkbox" id="select-all"> <!-- Select All checkbox -->
                 </th>
                 <th>DETAIL</th>
-                <th>{{ $suplemen->sasaran == 1 ? 'NO.' : 'NIK' }} KK</th>
-                <th>{{ $suplemen->sasaran == 1 ? 'NIK PENDUDUK' : 'NO. KK' }}</th>
-                <th>{{ $suplemen->sasaran == 1 ? 'NAMA PENDUDUK' : 'KEPALA KELUARGA' }}</th>
+                <th>{{ $suplemen->sasaran === 'Penduduk' ? 'NO.' : 'NIK' }} KK</th>
+                <th>{{ $suplemen->sasaran === 'Penduduk' ? 'NIK PENDUDUK' : 'NO. KK' }}</th>
+                <th>{{ $suplemen->sasaran === 'Penduduk' ? 'NAMA PENDUDUK' : 'KEPALA KELUARGA' }}</th>
                 <th>TEMPAT LAHIR</th>
                 <th>TANGGAL LAHIR</th>
                 <th>JENIS KELAMIN</th>


### PR DESCRIPTION
# Pull Request: Fix Error Halaman Detail Suplemen dan Refactor ke Service Layer

## Description

Fix error "Call to undefined function selected()" pada halaman edit suplemen serta refactor data access dari Eloquent model langsung ke `SuplemenService` yang melakukan API request. Perubahan ini menyesuaikan field mapping antara API response (menggunakan `sasaran` string dan `sasaran_id`/`status_id` numeric) dengan template Blade yang sebelumnya mengharapkan format berbeda.

### Changes made:

1. **New File**: `app/Services/SuplemenService.php` — Membuat service class baru yang mengakses data suplemen melalui API (`/api/v1/suplemen`) dengan caching, menggantikan Eloquent model `Suplemen::findOrFail()`.
2. **Refactor**: `app/Http/Controllers/SuplemenController.php` — Menggunakan dependency injection `SuplemenService` pada constructor, mengganti semua query Eloquent (`Suplemen`, `SuplemenTerdata`, `Config`, `Wilayah`) menjadi method call ke service.
3. **Bug Fix**: `resources/views/suplemen/edit.blade.php` — Mengganti `selected()` helper yang tidak ada dengan inline ternary operator, serta menyesuaikan field mapping (`$suplemen->sasaran_id`, `$suplemen->status_id`).
4. **Fix Template**: `resources/views/suplemen/cetak/table.blade.php` dan `resources/views/suplemen/table_terdata.blade.php` — Mengubah perbandingan numeric (`$suplemen->sasaran == 1`) menjadi string comparison (`$suplemen->sasaran === 'Penduduk'`).
5. **Fix Template**: `resources/views/suplemen/cetak/data_suplemen.blade.php` dan `resources/views/suplemen/rincian.blade.php` — Menghapus array lookup `$sasaran[$suplemen->sasaran]` karena data sasaran sudah berupa string dari API.
6. **Fix JS**: `resources/views/suplemen/js/data_suplemen_terdata.blade.php` — Mengubah `$suplemen->sasaran` menjadi `$suplemen->sasaran_id` untuk URL API terdata.
7. **Simplify**: `resources/views/suplemen/preview_js.blade.php` — Menyederhanakan logika preview sasaran dan status karena data sudah dalam format final dari API.

### Reason for change:

- **Error Fix**: `selected()` bukan helper function bawaan Laravel, sehingga menyebabkan fatal error saat membuka halaman edit suplemen.
- **Data Format Mismatch**: API mengembalikan data dengan field `sasaran` (string seperti "Penduduk"/"Hamil") dan `sasaran_id` (numeric), sedangkan template Blade sebelumnya menggunakan numeric `sasaran` dengan array lookup dari constant `SASARAN`.
- **Architectural Improvement**: Mengganti direct Eloquent query ke service layer untuk konsistensi akses data melalui API (pattern yang sama dengan service lainnya).

### Impact of change:

✅ **Bug Fix**: Error "Call to undefined function selected()" pada halaman edit suplemen teratasi
✅ **Data Consistency**: Template Blade menggunakan format data yang sesuai dengan API response
✅ **Maintainability**: Akses data terpusat di `SuplemenService`, memudahkan maintenance dan testing
✅ **Cache Strategy**: `suplemenById()` tidak menggunakan cache untuk data real-time, method lain tetap ter-cache
✅ **Export Fix**: Data cetak/ekspor menggunakan format sasaran string yang benar

## Related Issue

- Solution for fix related to issue [#1078](https://github.com/OpenSID/OpenKab/issues/1078)

## Steps to Reproduce

### Before fix (problem):
1. Buka halaman admin OpenKab
2. Navigasi ke menu Data Suplemen
3. Klik tombol "Edit" atau "Detail" pada salah satu data suplemen
4. ❌ Error: "Call to undefined function selected()" di `edit.blade.php:65`
5. ❌ Halaman tidak dapat dibuka sama sekali

### After fix (solution):
1. Buka halaman admin OpenKab
2. Navigasi ke menu Data Suplemen
3. Klik tombol "Edit" atau "Detail" pada salah satu data suplemen
4. ✅ Halaman terbuka normal tanpa error
5. ✅ Form edit menampilkan data dengan benar (sasaran, nama, keterangan, status)
6. ✅ Status dropdown (Aktif/Tidak Aktif) berfungsi dengan benar

### Testing on related features:
- Halaman list suplemen ✅ Normal
- Halaman detail suplemen ✅ Normal
- Halaman edit suplemen ✅ Normal (fix error selected())
- Export/Download Excel ✅ Normal
- Cetak data suplemen ✅ Normal
- Preview sebelum simpan ✅ Normal
- DataTable terdata ✅ Normal

## Checklist

- [x] I have complied with [script writing rules](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
- [x] I have followed [pull request review process](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
- [x] Manual testing has been done in development environment
- [x] No console errors or warnings
- [ ] I have created unit test to verify the fix

## Technical Details

### Technical Explanation

Sebelum refactor, `SuplemenController` mengakses data langsung menggunakan Eloquent model:
```php
// Sebelumnya (error)
$suplemen = Suplemen::with('terdata')->findOrFail($id);
```

Setelah refactor, semua akses data melalui `SuplemenService` yang melakukan API request:
```php
// Sesudahnya
$suplemen = $this->service->suplemenById($id);
```

API mengembalikan data dengan format:
- `sasaran`: string ("Penduduk", "Keluarga", dll)
- `sasaran_id`: numeric (1, 2, dll)
- `status`: string ("Aktif", "Tidak Aktif")
- `status_id`: numeric (1, 0)

Template Blade disesuaikan untuk menggunakan field yang benar:
```php
// Sebelumnya (error)
<option value="1" {{ selected(1, $suplemen->status) }}>

// Sesudahnya (fix)
<option value="1" {{ $suplemen->status_id == 1 ? 'selected' : '' }}>
```

### Field Mapping

| Field | API Response | Template View (Before) | Template View (After) |
|-------|-------------|------------------------|----------------------|
| sasaran | `"Penduduk"` (string) | `$suplemen->sasaran == 1` (numeric) | `$suplemen->sasaran === 'Penduduk'` (string) |
| sasaran_id | `1` (numeric) | `$suplemen->sasaran` (assumed numeric) | `$suplemen->sasaran_id` (explicit) |
| status | `"Aktif"` (string) | `selected(1, $suplemen->status)` | `$suplemen->status_id == 1` |
| status_id | `1` (numeric) | - | `$suplemen->status_id` |

### Dependencies added

- No new dependencies (menggunakan `BaseApiService` yang sudah ada)

## Testing

### Manual Testing

- [ ] Buka halaman list data suplemen
- [ ] Klik tombol "Tambah" — form tambah suplemen terbuka
- [ ] Klik tombol "Edit" — form edit suplemen terbuka tanpa error
- [ ] Ubah data suplemen (sasaran, nama, keterangan, status) dan simpan
- [ ] Klik tombol "Detail" — halaman detail suplemen terbuka
- [ ] Klik tombol "Export/Download" — file Excel terdownload
- [ ] Klik tombol "Cetak" — halaman cetak terbuka dengan benar
- [ ] Test preview sebelum simpan
- [ ] Regression testing: fitur lain tidak terpengaruh

## Breaking Changes

None — Perubahan ini backward compatible. API response format sudah ada sebelumnya, hanya template Blade yang disesuaikan.

## Migration Guide

Not required

## References

- [Issue #1078](https://github.com/OpenSID/OpenKab/issues/1078)
- `app/Services/BaseApiService.php` — Parent class untuk API service
- `app/Services/SuplemenService.php` — Service baru untuk akses data suplemen

## Depedency

https://github.com/OpenSID/API-Database-Gabungan/pull/441

## Video

https://github.com/user-attachments/assets/17fe0140-ea2c-44a8-b254-dc063b0b8a00

---

**Additional notes:** PR ini menggabungkan bug fix (`selected()` error) dan refactor (Eloquent ke Service). Untuk reviewer, mohon pastikan field mapping `sasaran` vs `sasaran_id` dan `status` vs `status_id` sudah sesuai dengan API response di `OpenSID/API-Database-Gabungan`.
