### PR TITLE
Fix: perbaikan error ketika buka website

### DIFF
--- a/app/Observers/VisitorObserver.php
+++ b/app/Observers/VisitorObserver.php
@@ -28,8 +28,7 @@ class VisitorObserver
 
             static::$updating = true;
 
-            $visit->update([
-                'location' => $location->toJson(),
+            $visit->update([                
                 'country_code' => $location->countryCode,
                 'country' => $location->countryName,
                 'region' => $location->regionCode,

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -7,6 +7,8 @@ Di rilis ini, versi 2607.0.0 berisi penambahan dan perbaikan yang diminta penggu
 1. [#1094](https://github.com/OpenSID/OpenKab/issues/1094) Perbaikan pangan error data table.
 2. [#1098](https://github.com/OpenSID/OpenKab/issues/1098) Perbaikan tampilan durasi lockout akun login (menit dan detik) serta koreksi perhitungan selisih waktu carbon.
 3. [#1100](https://github.com/OpenSID/OpenKab/issues/1100) Lengkapi fungsi laporan desa aktif.
+4. [#1083](https://github.com/OpenSID/OpenKab/issues/1083) Perbaikan ketika buka website default OpenKab.
+ 
 
 #### Perubahan Teknis
 

--- a/tests/Feature/WebsiteHomePageTest.php
+++ b/tests/Feature/WebsiteHomePageTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\WebsiteTestCase;
+
+class WebsiteHomePageTest extends WebsiteTestCase
+{
+    #[Test]
+    public function it_opens_website_home_page_when_website_enabled_and_default_page_selected()
+    {
+        $response = $this->get(route('web.index'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('web.index');
+        $response->assertViewHas('categoriesItems');
+        $response->assertViewHas('listKabupaten');
+        $response->assertViewHas('listKecamatan');
+        $response->assertViewHas('listDesa');
+    }
+
+    #[Test]
+    public function it_redirects_to_login_when_website_is_disabled()
+    {
+        Setting::updateOrCreate(
+            ['key' => 'website_enable'],
+            ['value' => 0]
+        );
+
+        $response = $this->get(route('web.index'));
+
+        $response->assertRedirect('/login');
+    }
+
+    #[Test]
+    public function it_redirects_to_presisi_when_home_page_is_set_to_presisi()
+    {
+        Setting::updateOrCreate(
+            ['key' => 'home_page'],
+            ['value' => 'presisi']
+        );
+
+        $response = $this->get(route('web.index'));
+
+        $response->assertRedirect('presisi');
+    }
+}


### PR DESCRIPTION
# Pull Request: Fix error when opening website and add feature test

## Description

Perbaiki error `Call to undefined method toJson()` pada VisitorObserver ketika membuka halaman website, serta menambahkan feature test untuk memastikan halaman website dapat diakses dengan syarat pengaturan website enable dan memilih halaman default.

### Changes made:

1. **Bug Fix**: Hapus `location` field dari update array di `VisitorObserver` karena method `toJson()` tidak tersedia pada objek location, menyebabkan error saat mengakses halaman website.
2. **Feature Test**: Tambahkan `WebsiteHomePageTest` yang mencakup 3 skenario:
   - Website enable + home_page=default → halaman terbuka (200)
   - Website disabled → redirect ke `/login`
   - home_page=presisi → redirect ke `/presisi`

### Reason for change:

- **Point 1**: Error `Call to undefined method toJson()` terjadi karena class `Location` tidak memiliki method `toJson()`, sehingga menyebabkan halaman website tidak bisa diakses (error 500).
- **Point 2**: Belum ada test coverage untuk halaman website, sehingga regression tidak terdeteksi.
- **Point 3**: Test memverifikasi middleware `WebsiteEnable` bekerja sesuai spesifikasi.

### Impact of change:

✅ **Bug Fix**: Halaman website dapat diakses tanpa error.
✅ **Test Coverage**: 3 test case untuk memastikan middleware website berfungsi.
✅ **Regression Protection**: Perubahan middleware tidak akan lolos tanpa test.

## Related Issue

- Solution for fix related to issue #1083

https://github.com/OpenSID/OpenKab/issues/1083

## Steps to Reproduce

### Before fix (problem):
1. Buka halaman website OpenKab (`GET /`)
2. ❌ Error 500: `Call to undefined method Stevebauman\Location\Location::toJson()`

### After fix (solution):
1. Buka halaman website OpenKab (`GET /`)
2. ✅ Halaman terbuka dengan normal (200)

### Testing on related features:
- Fitur Visitor location tracking ✅ Tidak ada error saat mencatat kunjungan
- Halaman website ✅ Berfungsi normal
- Halaman admin ✅ Tidak terpengaruh

## Checklist
- [x] I have complied with [script writing rules](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
- [x] I have followed [pull request review process](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
- [x] I have created [unit test/integration test] to verify the fix
- [x] Manual testing has been done in development environment
- [x] No console errors or warnings
- [ ] Code has been reviewed by [at least 1 person]

## Technical Details

### Technical Explanation

`VisitorObserver@created` memanggil `$location->toJson()` pada object dari `Stevebauman\Location\Facades\Location::get($ip)`. Method `toJson()` tidak tersedia di class `Location`, sehingga menyebabkan error.

Perbaikan: Hapus field `location` dari array update karena:
1. Method `toJson()` tidak tersedia di class `Location` → error 500
2. Field `location` tidak ada di tabel `visits` (berdasarkan migration)
3. Field `location` tidak masuk dalam property `$fillable` model `Visit`, sehingga mass assignment akan mengabaikannya secara diam-diam meskipun method `toJson()` tersedia

```diff
 $visit->update([
-    'location' => $location->toJson(),
     'country_code' => $location->countryCode,
```

Feature test menggunakan `WebsiteTestCase` yang sudah mengatur setting `website_enable=1` dan `home_page='default'`, serta memverifikasi middleware `WebsiteEnable` berjalan sesuai spesifikasi:

- Jika `website_enable=0` → redirect ke `/login`
- Jika `home_page='presisi'` → redirect ke `/presisi`
- Jika keduanya sesuai → akses halaman index (200)

### Configuration changes
None

### Dependencies added
No new dependencies

## Testing

### Manual Testing
- [x] Buka halaman website OpenKab dan pastikan tidak ada error
- [x] Nonaktifkan website via pengaturan → redirect ke login
- [x] Set halaman utama ke Presisi → redirect ke halaman presisi

### Automated Testing
- [x] `WebsiteHomePageTest::it_opens_website_home_page_when_website_enabled_and_default_page_selected`
- [x] `WebsiteHomePageTest::it_redirects_to_login_when_website_is_disabled`
- [x] `WebsiteHomePageTest::it_redirects_to_presisi_when_home_page_is_set_to_presisi`

## Screenshots / Video

<img width="852" height="318" alt="image" src="https://github.com/user-attachments/assets/8125106b-4e68-4653-b56c-02224ea98fe3" />

### Before:
Error 500 saat membuka halaman website (Call to undefined method toJson())

### After:
Halaman website terbuka normal (200 OK)

## Breaking Changes
None

## Migration Guide
Not required

## References
- https://github.com/OpenSID/OpenKab/issues/1083

---

**Additional notes:** Test sudah dijalankan dan 3/3 passed (10 assertions).
