### PR TITLE
Feat: backup restore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ AGENTS.md
 tests/Browser/Screenshots/
 tests/Browser/screenshots/
 tests/Browser/.session_state.json
+graphify-out

--- a/app/Enums/Modul.php
+++ b/app/Enums/Modul.php
@@ -443,7 +443,13 @@ final class Modul extends Enum
                     'text' => 'Aktivasi OTP dan 2FA',
                     'icon' => 'far fa-fw fa-circle',
                     'url' => 'pengaturan/otp',
-                ]
+                ],
+                [
+                    'icon' => 'far fa-fw fa-circle',
+                    'text' => 'Backup Database',
+                    'url' => 'pengaturan/backup',
+                    'permission' => 'pengaturan-backup',
+                ],
             ],
         ],
     ];

--- a/app/Enums/Modul.php
+++ b/app/Enums/Modul.php
@@ -446,9 +446,9 @@ final class Modul extends Enum
                 ],
                 [
                     'icon' => 'far fa-fw fa-circle',
-                    'text' => 'Backup Database',
-                    'url' => 'pengaturan/backup',
-                    'permission' => 'pengaturan-backup',
+                    'text' => 'Database',
+                    'url' => 'pengaturan/database',
+                    'permission' => 'pengaturan-database',
                 ],
             ],
         ],

--- a/app/Http/Controllers/BackupController.php
+++ b/app/Http/Controllers/BackupController.php
@@ -244,10 +244,16 @@ class BackupController extends AppBaseController
             return $sqlFiles[0];
         }
 
-        $dumperFiles = glob($tempPath . '/*/db-dumps/*.sql');
+        $dumperFiles = glob($tempPath . '/db-dumps/*.sql');
 
         if (! empty($dumperFiles)) {
             return $dumperFiles[0];
+        }
+
+        $nestedDumperFiles = glob($tempPath . '/*/db-dumps/*.sql');
+
+        if (! empty($nestedDumperFiles)) {
+            return $nestedDumperFiles[0];
         }
 
         return null;

--- a/app/Http/Controllers/BackupController.php
+++ b/app/Http/Controllers/BackupController.php
@@ -20,7 +20,7 @@ class BackupController extends AppBaseController
 {
     use UploadedFile;
 
-    protected $permission = 'pengaturan-backup';
+    protected $permission = 'pengaturan-database';
 
     protected string $diskName = 'backups';
 

--- a/app/Http/Controllers/BackupController.php
+++ b/app/Http/Controllers/BackupController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\RestoreBackupRequest;
 use App\Traits\UploadedFile;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -108,6 +109,14 @@ class BackupController extends AppBaseController
                 throw new Exception('Tidak dapat membuka file backup.');
             }
 
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $entry = $zip->getNameIndex($i);
+                if (str_contains($entry, '..') || str_starts_with($entry, '/')) {
+                    $zip->close();
+                    throw new Exception('File backup tidak valid.');
+                }
+            }
+
             $zip->extractTo($tempPath);
             $zip->close();
 
@@ -128,7 +137,7 @@ class BackupController extends AppBaseController
         }
     }
 
-    public function uploadAndRestore(Request $request): JsonResponse
+    public function uploadAndRestore(RestoreBackupRequest $request): JsonResponse
     {
         $this->pathFolder = 'backups_upload';
         $relativePath = $this->uploadFile($request, 'file');
@@ -137,13 +146,24 @@ class BackupController extends AppBaseController
             return $this->sendError('Gagal mengupload file.', 500);
         }
 
-        $fullPath = storage_path('app/public/' . $relativePath);
+        $publicPath = storage_path('app/public/' . $relativePath);
+        $tempZipPath = storage_path('app/backups/temp_upload_' . uniqid() . '.zip');
         $tempPath = storage_path('app/backups/temp_restore_' . uniqid());
+
+        rename($publicPath, $tempZipPath);
 
         try {
             $zip = new ZipArchive;
-            if ($zip->open($fullPath) !== true) {
+            if ($zip->open($tempZipPath) !== true) {
                 throw new Exception('Tidak dapat membuka file backup.');
+            }
+
+            for ($i = 0; $i < $zip->numFiles; $i++) {
+                $entry = $zip->getNameIndex($i);
+                if (str_contains($entry, '..') || str_starts_with($entry, '/')) {
+                    $zip->close();
+                    throw new Exception('File backup tidak valid.');
+                }
             }
 
             $zip->extractTo($tempPath);
@@ -153,14 +173,14 @@ class BackupController extends AppBaseController
             $this->restoreStorageFiles($tempPath);
 
             $this->cleanTempDir($tempPath);
-            @unlink($fullPath);
+            @unlink($tempZipPath);
 
             Log::warning('Restore database dan storage dari upload oleh ' . (auth()->user()?->username ?? 'system'));
 
             return $this->sendSuccess('Restore database dan storage berhasil.');
         } catch (Exception $e) {
             $this->cleanTempDir($tempPath);
-            @unlink($fullPath);
+            @unlink($tempZipPath);
 
             Log::error('Restore dari upload gagal: ' . $e->getMessage());
 

--- a/app/Http/Controllers/BackupController.php
+++ b/app/Http/Controllers/BackupController.php
@@ -1,0 +1,260 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Traits\UploadedFile;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use ZipArchive;
+
+class BackupController extends AppBaseController
+{
+    use UploadedFile;
+
+    protected $permission = 'pengaturan-backup';
+
+    protected string $diskName = 'backups';
+
+    public function index(): \Illuminate\View\View
+    {
+        $listPermission = $this->generateListPermission();
+
+        $backups = collect(Storage::disk($this->diskName)->files())
+            ->filter(fn (string $file): bool => str_ends_with($file, '.zip'))
+            ->map(fn (string $file): array => [
+                'filename' => basename($file),
+                'size' => Storage::disk($this->diskName)->size($file),
+                'last_modified' => Storage::disk($this->diskName)->lastModified($file),
+            ])
+            ->sortByDesc('last_modified')
+            ->values();
+
+        return view('backup.index', compact('backups'))->with($listPermission);
+    }
+
+    public function run(): JsonResponse
+    {
+        try {
+            $exitCode = Artisan::call('backup:run', [
+                '--disable-notifications' => true,
+            ]);
+
+            if ($exitCode === 0) {
+                Log::info('Backup database dan storage berhasil dibuat oleh ' . (auth()->user()?->username ?? 'system'));
+
+                return $this->sendSuccess('Backup berhasil dibuat.');
+            }
+
+            return $this->sendError('Backup gagal: ' . Artisan::output(), 500);
+        } catch (Exception $e) {
+            Log::error('Backup gagal: ' . $e->getMessage());
+
+            return $this->sendError('Backup gagal: ' . $e->getMessage(), 500);
+        }
+    }
+
+    public function download(string $filename): BinaryFileResponse|RedirectResponse|StreamedResponse
+    {
+        abort_if(! $this->isValidFilename($filename), 400, 'Nama file tidak valid.');
+
+        $disk = Storage::disk($this->diskName);
+
+        abort_if(! $disk->exists($filename), 404, 'File backup tidak ditemukan.');
+
+        return $disk->download($filename);
+    }
+
+    public function destroy(string $filename): JsonResponse
+    {
+        abort_if(! $this->isValidFilename($filename), 400, 'Nama file tidak valid.');
+
+        $disk = Storage::disk($this->diskName);
+
+        if (! $disk->exists($filename)) {
+            return $this->sendError('File backup tidak ditemukan.', 404);
+        }
+
+        $disk->delete($filename);
+
+        Log::info('Backup ' . $filename . ' dihapus oleh ' . (auth()->user()?->username ?? 'system'));
+
+        return $this->sendSuccess('Backup berhasil dihapus.');
+    }
+
+    public function restore(string $filename): JsonResponse
+    {
+        abort_if(! $this->isValidFilename($filename), 400, 'Nama file tidak valid.');
+
+        $disk = Storage::disk($this->diskName);
+
+        if (! $disk->exists($filename)) {
+            return $this->sendError('File backup tidak ditemukan.', 404);
+        }
+
+        $tempPath = storage_path('app/backups/temp_restore_' . uniqid());
+        $zipPath = $disk->path($filename);
+
+        try {
+            $zip = new ZipArchive;
+            if ($zip->open($zipPath) !== true) {
+                throw new Exception('Tidak dapat membuka file backup.');
+            }
+
+            $zip->extractTo($tempPath);
+            $zip->close();
+
+            $this->restoreDatabase($tempPath);
+            $this->restoreStorageFiles($tempPath);
+
+            $this->cleanTempDir($tempPath);
+
+            Log::warning('Restore database dan storage dari ' . $filename . ' oleh ' . (auth()->user()?->username ?? 'system'));
+
+            return $this->sendSuccess('Restore database dan storage berhasil.');
+        } catch (Exception $e) {
+            $this->cleanTempDir($tempPath);
+
+            Log::error('Restore gagal dari ' . $filename . ': ' . $e->getMessage());
+
+            return $this->sendError('Restore gagal: ' . $e->getMessage(), 500);
+        }
+    }
+
+    public function uploadAndRestore(Request $request): JsonResponse
+    {
+        $this->pathFolder = 'backups_upload';
+        $relativePath = $this->uploadFile($request, 'file');
+
+        if ($relativePath === false) {
+            return $this->sendError('Gagal mengupload file.', 500);
+        }
+
+        $fullPath = storage_path('app/public/' . $relativePath);
+        $tempPath = storage_path('app/backups/temp_restore_' . uniqid());
+
+        try {
+            $zip = new ZipArchive;
+            if ($zip->open($fullPath) !== true) {
+                throw new Exception('Tidak dapat membuka file backup.');
+            }
+
+            $zip->extractTo($tempPath);
+            $zip->close();
+
+            $this->restoreDatabase($tempPath);
+            $this->restoreStorageFiles($tempPath);
+
+            $this->cleanTempDir($tempPath);
+            @unlink($fullPath);
+
+            Log::warning('Restore database dan storage dari upload oleh ' . (auth()->user()?->username ?? 'system'));
+
+            return $this->sendSuccess('Restore database dan storage berhasil.');
+        } catch (Exception $e) {
+            $this->cleanTempDir($tempPath);
+            @unlink($fullPath);
+
+            Log::error('Restore dari upload gagal: ' . $e->getMessage());
+
+            return $this->sendError('Restore gagal: ' . $e->getMessage(), 500);
+        }
+    }
+
+    private function restoreDatabase(string $tempPath): void
+    {
+        $sqlFile = $this->findSqlFile($tempPath);
+
+        if ($sqlFile === null) {
+            throw new Exception('File SQL backup tidak ditemukan dalam arsip.');
+        }
+
+        $sql = file_get_contents($sqlFile);
+
+        if ($sql === false || trim($sql) === '') {
+            throw new Exception('File SQL backup kosong atau tidak dapat dibaca.');
+        }
+
+        DB::unprepared($sql);
+    }
+
+    private function restoreStorageFiles(string $tempPath): void
+    {
+        $storageSource = $tempPath . '/storage/app';
+
+        if (! is_dir($storageSource)) {
+            Log::info('Direktori storage/app tidak ditemukan dalam backup, melewati.');
+
+            return;
+        }
+
+        $target = storage_path('app');
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($storageSource, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        foreach ($files as $file) {
+            $relativePath = substr($file->getRealPath(), strlen($storageSource));
+            $destPath = $target . $relativePath;
+
+            if ($file->isDir()) {
+                if (! is_dir($destPath)) {
+                    mkdir($destPath, 0755, true);
+                }
+            } else {
+                copy($file->getRealPath(), $destPath);
+            }
+        }
+    }
+
+    private function findSqlFile(string $tempPath): ?string
+    {
+        $sqlFiles = glob($tempPath . '/*.sql');
+
+        if (! empty($sqlFiles)) {
+            return $sqlFiles[0];
+        }
+
+        $dumperFiles = glob($tempPath . '/*/db-dumps/*.sql');
+
+        if (! empty($dumperFiles)) {
+            return $dumperFiles[0];
+        }
+
+        return null;
+    }
+
+    private function cleanTempDir(string $tempPath): void
+    {
+        if (! is_dir($tempPath)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($tempPath, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? @rmdir($file->getRealPath()) : @unlink($file->getRealPath());
+        }
+
+        @rmdir($tempPath);
+    }
+
+    private function isValidFilename(string $filename): bool
+    {
+        return preg_match('/^[\w\.\-]+\.zip$/', $filename) === 1
+            && ! str_contains($filename, '..')
+            && ! str_contains($filename, '/');
+    }
+}

--- a/app/Http/Middleware/EasyAuthorize.php
+++ b/app/Http/Middleware/EasyAuthorize.php
@@ -47,6 +47,7 @@ class EasyAuthorize
             'destroy' => 'delete',
             'update' => 'edit',
             'edit' => 'edit',
+            'upload' => 'write',
         ];
         $route = $request->route()->getName();
         $tmp = explode('.', $route);

--- a/app/Http/Requests/RestoreBackupRequest.php
+++ b/app/Http/Requests/RestoreBackupRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RestoreBackupRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'file' => 'required|file|mimes:zip|max:' . (50 * 1024),
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "proengsoft/laravel-jsvalidation": "^4.8",
         "shetabit/visitor": "^4.1",
         "spatie/laravel-activitylog": "^4.7",
+        "spatie/laravel-backup": "^10.3",
         "spatie/laravel-csp": "^3.0",
         "spatie/laravel-fractal": "^6.0",
         "spatie/laravel-html": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27d97b095c210931e907629054c7d0ad",
+    "content-hash": "17ee6ab8193b6804b4d6ac449a7f897a",
     "packages": [
         {
             "name": "akaunting/laravel-apexcharts",
@@ -5948,6 +5948,70 @@
             "time": "2026-05-19T20:15:12+00:00"
         },
         {
+            "name": "spatie/db-dumper",
+            "version": "4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/db-dumper.git",
+                "reference": "f8f2785574de84aa4642a4df8b59a6dd578dd5d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/db-dumper/zipball/f8f2785574de84aa4642a4df8b59a6dd578dd5d3",
+                "reference": "f8f2785574de84aa4642a4df8b59a6dd578dd5d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.3",
+                "symfony/process": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\DbDumper\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Dump databases",
+            "homepage": "https://github.com/spatie/db-dumper",
+            "keywords": [
+                "database",
+                "db-dumper",
+                "dump",
+                "mysqldump",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/db-dumper/tree/4.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-04T11:43:33+00:00"
+        },
+        {
             "name": "spatie/fractalistic",
             "version": "2.11.1",
             "source": {
@@ -6099,6 +6163,106 @@
                 }
             ],
             "time": "2026-03-24T12:33:53+00:00"
+        },
+        {
+            "name": "spatie/laravel-backup",
+            "version": "10.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-backup.git",
+                "reference": "c026344f7e26321d6e1d214cd3e566ce5c54715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-backup/zipball/c026344f7e26321d6e1d214cd3e566ce5c54715d",
+                "reference": "c026344f7e26321d6e1d214cd3e566ce5c54715d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-zip": "^1.14.0",
+                "illuminate/console": "^12.40|^13.0",
+                "illuminate/contracts": "^12.40|^13.0",
+                "illuminate/events": "^12.40|^13.0",
+                "illuminate/filesystem": "^12.40|^13.0",
+                "illuminate/notifications": "^12.40|^13.0",
+                "illuminate/support": "^12.40|^13.0",
+                "league/flysystem": "^3.30.2",
+                "php": "^8.3",
+                "spatie/db-dumper": "^4.0",
+                "spatie/laravel-package-tools": "^1.92.7",
+                "spatie/laravel-signal-aware-command": "^2.1",
+                "spatie/temporary-directory": "^2.3",
+                "symfony/console": "^7.3.6|^8.0",
+                "symfony/finder": "^7.3.5|^8.0"
+            },
+            "require-dev": {
+                "composer-runtime-api": "^2.0",
+                "ext-pcntl": "*",
+                "larastan/larastan": "^3.8",
+                "laravel/slack-notification-channel": "^3.7",
+                "league/flysystem-aws-s3-v3": "^3.30.1",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.8|^11.0",
+                "pestphp/pest": "^4.1.5",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan-deprecation-rules": "^2.0.3",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "rector/rector": "^2.2.8"
+            },
+            "suggest": {
+                "laravel/slack-notification-channel": "Required for sending notifications via Slack"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\Backup\\BackupServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Helpers/functions.php"
+                ],
+                "psr-4": {
+                    "Spatie\\Backup\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Laravel package to backup your application",
+            "homepage": "https://github.com/spatie/laravel-backup",
+            "keywords": [
+                "backup",
+                "database",
+                "laravel-backup",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-backup/issues",
+                "source": "https://github.com/spatie/laravel-backup/tree/10.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/spatie",
+                    "type": "github"
+                },
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-06-10T08:25:59+00:00"
         },
         {
             "name": "spatie/laravel-csp",
@@ -6629,6 +6793,142 @@
                 }
             ],
             "time": "2026-03-08T13:45:05+00:00"
+        },
+        {
+            "name": "spatie/laravel-signal-aware-command",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-signal-aware-command.git",
+                "reference": "54dcc1efd152bfb3eb0faf56a5fc28569b864b5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-signal-aware-command/zipball/54dcc1efd152bfb3eb0faf56a5fc28569b864b5d",
+                "reference": "54dcc1efd152bfb3eb0faf56a5fc28569b864b5d",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^11.0|^12.0|^13.0",
+                "php": "^8.2",
+                "spatie/laravel-package-tools": "^1.4.3",
+                "symfony/console": "^7.0|^8.0"
+            },
+            "require-dev": {
+                "brianium/paratest": "^6.2|^7.0",
+                "ext-pcntl": "*",
+                "nunomaduro/collision": "^5.3|^6.0|^7.0|^8.0",
+                "orchestra/testbench": "^9.0|^10.0",
+                "pestphp/pest-plugin-laravel": "^1.3|^2.0|^3.0",
+                "phpunit/phpunit": "^9.5|^10|^11",
+                "spatie/laravel-ray": "^1.17"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Signal": "Spatie\\SignalAwareCommand\\Facades\\Signal"
+                    },
+                    "providers": [
+                        "Spatie\\SignalAwareCommand\\SignalAwareCommandServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\SignalAwareCommand\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Handle signals in artisan commands",
+            "homepage": "https://github.com/spatie/laravel-signal-aware-command",
+            "keywords": [
+                "laravel",
+                "laravel-signal-aware-command",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-signal-aware-command/issues",
+                "source": "https://github.com/spatie/laravel-signal-aware-command/tree/2.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-22T08:16:31+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "2.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "32cbb9645b28839cf4f476708e99a2c70e6802c9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/32cbb9645b28839cf4f476708e99a2c70e6802c9",
+                "reference": "32cbb9645b28839cf4f476708e99a2c70e6802c9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "php",
+                "spatie",
+                "temporary-directory"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/temporary-directory/issues",
+                "source": "https://github.com/spatie/temporary-directory/tree/2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-22T07:55:44+00:00"
         },
         {
             "name": "stevebauman/location",

--- a/config/backup.php
+++ b/config/backup.php
@@ -18,7 +18,7 @@ return [
          * The name of this application. You can use this name to monitor
          * the backups.
          */
-        'name' => env('APP_NAME', 'laravel-backup'),
+        'name' => '',
 
         'source' => [
             'files' => [

--- a/config/backup.php
+++ b/config/backup.php
@@ -271,7 +271,7 @@ return [
      */
     'monitor_backups' => [
         [
-            'name' => env('APP_NAME', 'laravel-backup'),
+        'name' => '',
             'disks' => ['local'],
             'health_checks' => [
                 MaximumAgeInDays::class => 1,

--- a/config/backup.php
+++ b/config/backup.php
@@ -1,0 +1,358 @@
+<?php
+
+use Spatie\Backup\Notifications\Notifiable;
+use Spatie\Backup\Notifications\Notifications\BackupHasFailedNotification;
+use Spatie\Backup\Notifications\Notifications\BackupWasSuccessfulNotification;
+use Spatie\Backup\Notifications\Notifications\CleanupHasFailedNotification;
+use Spatie\Backup\Notifications\Notifications\CleanupWasSuccessfulNotification;
+use Spatie\Backup\Notifications\Notifications\HealthyBackupWasFoundNotification;
+use Spatie\Backup\Notifications\Notifications\UnhealthyBackupWasFoundNotification;
+use Spatie\Backup\Tasks\Cleanup\Strategies\DefaultStrategy;
+use Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays;
+use Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes;
+
+return [
+
+    'backup' => [
+        /*
+         * The name of this application. You can use this name to monitor
+         * the backups.
+         */
+        'name' => env('APP_NAME', 'laravel-backup'),
+
+        'source' => [
+            'files' => [
+                'include' => [
+                    storage_path('app'),
+                ],
+                'exclude' => [
+                    storage_path('app/backups'),
+                    storage_path('app/backup-temp'),
+                ],
+                'follow_links' => false,
+                'ignore_unreadable_directories' => false,
+                'relative_path' => base_path(),
+            ],
+
+            /*
+             * The names of the connections to the databases that should be backed up
+             * MySQL, PostgreSQL, SQLite and Mongo databases are supported.
+             *
+             * The content of the database dump may be customized for each connection
+             * by adding a 'dump' key to the connection settings in config/database.php.
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'exclude_tables' => [
+             *                'table_to_exclude_from_backup',
+             *                'another_table_to_exclude'
+             *            ]
+             *       ],
+             * ],
+             *
+             * If you are using only InnoDB tables on a MySQL server, you can
+             * also supply the useSingleTransaction option to avoid table locking.
+             *
+             * E.g.
+             * 'mysql' => [
+             *       ...
+             *      'dump' => [
+             *           'useSingleTransaction' => true,
+             *       ],
+             * ],
+             *
+             * For a complete list of available customization options, see https://github.com/spatie/db-dumper
+             */
+            'databases' => [
+                env('DB_CONNECTION', 'mysql'),
+            ],
+        ],
+
+        /*
+         * The database dump can be compressed to decrease disk space usage.
+         *
+         * Out of the box Laravel-backup supplies
+         * Spatie\DbDumper\Compressors\GzipCompressor::class.
+         *
+         * You can also create custom compressor. More info on that here:
+         * https://github.com/spatie/db-dumper#using-compression
+         *
+         * If you do not want any compressor at all, set it to null.
+         */
+        'database_dump_compressor' => null,
+
+        /*
+         * If specified, the database dumped file name will contain a timestamp (e.g.: 'Y-m-d-H-i-s').
+         */
+        'database_dump_file_timestamp_format' => null,
+
+        /*
+         * The base of the dump filename, either 'database' or 'connection'
+         *
+         * If 'database' (default), the dumped filename will contain the database name.
+         * If 'connection', the dumped filename will contain the connection name.
+         */
+        'database_dump_filename_base' => 'database',
+
+        /*
+         * The file extension used for the database dump files.
+         *
+         * If not specified, the file extension will be .archive for MongoDB and .sql for all other databases
+         * The file extension should be specified without a leading .
+         */
+        'database_dump_file_extension' => '',
+
+        'destination' => [
+            /*
+             * The compression algorithm to be used for creating the zip archive.
+             *
+             * If backing up only database, you may choose gzip compression for db dump and no compression at zip.
+             *
+             * Some common algorithms are listed below:
+             * ZipArchive::CM_STORE (no compression at all; set 0 as compression level)
+             * ZipArchive::CM_DEFAULT
+             * ZipArchive::CM_DEFLATE
+             * ZipArchive::CM_BZIP2
+             * ZipArchive::CM_XZ
+             *
+             * For more check https://www.php.net/manual/zip.constants.php and confirm it's supported by your system.
+             */
+            'compression_method' => ZipArchive::CM_DEFAULT,
+
+            /*
+             * The compression level corresponding to the used algorithm; an integer between 0 and 9.
+             *
+             * Check supported levels for the chosen algorithm, usually 1 means the fastest and weakest compression,
+             * while 9 the slowest and strongest one.
+             *
+             * Setting of 0 for some algorithms may switch to the strongest compression.
+             */
+            'compression_level' => 9,
+
+            /*
+             * The filename prefix used for the backup zip file.
+             */
+            'filename_prefix' => '',
+
+            /*
+             * The disk names on which the backups will be stored.
+             */
+            'disks' => [
+                'backups',
+            ],
+
+            /*
+             * Determines whether to allow backups to continue when some targets fail instead of failing completely.
+             */
+            'continue_on_failure' => false,
+        ],
+
+        /*
+         * The directory where the temporary files will be stored.
+         */
+        'temporary_directory' => storage_path('app/backups/temp'),
+
+        /*
+         * The password to be used for archive encryption.
+         * Set to `null` to disable encryption.
+         */
+        'password' => env('BACKUP_ARCHIVE_PASSWORD'),
+
+        /*
+         * The encryption algorithm to be used for archive encryption.
+         * Set to 'none' to disable encryption.
+         *
+         * Supported: 'none', 'default', 'aes128', 'aes192', 'aes256'
+         *
+         * When set to 'default', we'll use AES-256 if available on your system.
+         */
+        'encryption' => 'default',
+
+        /*
+         * After creating the zip, verify it can be opened and contains files.
+         * Recommended for critical backups but adds a small overhead.
+         */
+        'verify_backup' => false,
+
+        /*
+         * The number of attempts, in case the backup command encounters an exception
+         */
+        'tries' => 1,
+
+        /*
+         * The number of seconds to wait before attempting a new backup if the previous try failed
+         * Set to `0` for none
+         */
+        'retry_delay' => 0,
+    ],
+
+    /*
+     * You can get notified when specific events occur. Out of the box you can use 'mail' and 'slack'.
+     * For Slack you need to install laravel/slack-notification-channel.
+     *
+     * You can also use your own notification classes, just make sure the class is named after one of
+     * the `Spatie\Backup\Notifications\Notifications` classes.
+     */
+    'notifications' => [
+        'notifications' => [
+            BackupHasFailedNotification::class => ['mail'],
+            UnhealthyBackupWasFoundNotification::class => ['mail'],
+            CleanupHasFailedNotification::class => ['mail'],
+            BackupWasSuccessfulNotification::class => ['mail'],
+            HealthyBackupWasFoundNotification::class => ['mail'],
+            CleanupWasSuccessfulNotification::class => ['mail'],
+        ],
+
+        /*
+         * Here you can specify the notifiable to which the notifications should be sent. The default
+         * notifiable will use the variables specified in this config file.
+         */
+        'notifiable' => Notifiable::class,
+
+        'mail' => [
+            'to' => 'your@example.com',
+
+            'from' => [
+                'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+                'name' => env('MAIL_FROM_NAME', 'Example'),
+            ],
+        ],
+
+        'slack' => [
+            'webhook_url' => '',
+
+            /*
+             * If this is set to null the default channel of the webhook will be used.
+             */
+            'channel' => null,
+
+            'username' => null,
+
+            'icon' => null,
+        ],
+
+        'discord' => [
+            'webhook_url' => '',
+
+            /*
+             * If this is an empty string, the name field on the webhook will be used.
+             */
+            'username' => '',
+
+            /*
+             * If this is an empty string, the avatar on the webhook will be used.
+             */
+            'avatar_url' => '',
+        ],
+
+        /*
+         * A generic webhook channel that POSTs JSON to a URL.
+         * Useful for Mattermost, Microsoft Teams, or custom integrations.
+         */
+        'webhook' => [
+            'url' => '',
+        ],
+    ],
+
+    /*
+     * The log channel used for backup activity messages.
+     *
+     * Set to a channel name defined in config/logging.php to use that channel.
+     * Set to false to disable backup logging entirely.
+     * Set to null to use the default log channel.
+     */
+    'log_channel' => null,
+
+    /*
+     * Here you can specify which backups should be monitored.
+     * If a backup does not meet the specified requirements the
+     * UnHealthyBackupWasFound event will be fired.
+     */
+    'monitor_backups' => [
+        [
+            'name' => env('APP_NAME', 'laravel-backup'),
+            'disks' => ['local'],
+            'health_checks' => [
+                MaximumAgeInDays::class => 1,
+                MaximumStorageInMegabytes::class => 5000,
+            ],
+        ],
+
+        /*
+        [
+            'name' => 'name of the second app',
+            'disks' => ['local', 's3'],
+            'health_checks' => [
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumAgeInDays::class => 1,
+                \Spatie\Backup\Tasks\Monitor\HealthChecks\MaximumStorageInMegabytes::class => 5000,
+            ],
+        ],
+        */
+    ],
+
+    'cleanup' => [
+        /*
+         * The strategy that will be used to cleanup old backups. The default strategy
+         * will keep all backups for a certain amount of days. After that period only
+         * a daily backup will be kept. After that period only weekly backups will
+         * be kept and so on.
+         *
+         * No matter how you configure it the default strategy will never
+         * delete the newest backup.
+         */
+        'strategy' => DefaultStrategy::class,
+
+        'default_strategy' => [
+            /*
+             * The number of days for which backups must be kept.
+             */
+            'keep_all_backups_for_days' => 7,
+
+            /*
+             * After the "keep_all_backups_for_days" period is over, the most recent backup
+             * of that day will be kept. Older backups within the same day will be removed.
+             * If you create backups only once a day, no backups will be removed yet.
+             */
+            'keep_daily_backups_for_days' => 16,
+
+            /*
+             * After the "keep_daily_backups_for_days" period is over, the most recent backup
+             * of that week will be kept. Older backups within the same week will be removed.
+             * If you create backups only once a week, no backups will be removed yet.
+             */
+            'keep_weekly_backups_for_weeks' => 8,
+
+            /*
+             * After the "keep_weekly_backups_for_weeks" period is over, the most recent backup
+             * of that month will be kept. Older backups within the same month will be removed.
+             */
+            'keep_monthly_backups_for_months' => 4,
+
+            /*
+             * After the "keep_monthly_backups_for_months" period is over, the most recent backup
+             * of that year will be kept. Older backups within the same year will be removed.
+             */
+            'keep_yearly_backups_for_years' => 2,
+
+            /*
+             * After cleaning up the backups remove the oldest backup until
+             * this amount of megabytes has been reached.
+             * Set null for unlimited size.
+             */
+            'delete_oldest_backups_when_using_more_megabytes_than' => 5000,
+        ],
+
+        /*
+         * The number of attempts, in case the cleanup command encounters an exception
+         */
+        'tries' => 1,
+
+        /*
+         * The number of seconds to wait before attempting a new cleanup if the previous try failed
+         * Set to `0` for none
+         */
+        'retry_delay' => 0,
+    ],
+
+];

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -52,6 +52,12 @@ return [
             'throw' => false,
         ],
 
+        'backups' => [
+            'driver' => 'local',
+            'root' => storage_path('app/backups/' . env('APP_NAME', 'laravel-backup')),
+            'throw' => false,
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -54,7 +54,7 @@ return [
 
         'backups' => [
             'driver' => 'local',
-            'root' => storage_path('app/backups/' . env('APP_NAME', 'laravel-backup')),
+            'root' => storage_path('app/backups'),
             'throw' => false,
         ],
 

--- a/database/migrations/2026_07_03_000001_add_backup_menu.php
+++ b/database/migrations/2026_07_03_000001_add_backup_menu.php
@@ -1,0 +1,17 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Artisan;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Artisan::call('admin:menu-update');
+    }
+
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2026_07_03_000002_add_backup_permissions.php
+++ b/database/migrations/2026_07_03_000002_add_backup_permissions.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $permissions = [
+            'pengaturan-backup-read',
+            'pengaturan-backup-write',
+            'pengaturan-backup-edit',
+            'pengaturan-backup-delete',
+        ];
+
+        foreach ($permissions as $name) {
+            Permission::findOrCreate($name, 'web');
+        }
+
+        $role = Role::where('name', 'administrator')->where('guard_name', 'web')->first();
+
+        if ($role) {
+            $role->givePermissionTo($permissions);
+        }
+    }
+
+    public function down(): void
+    {
+        Permission::whereIn('name', [
+            'pengaturan-backup-read',
+            'pengaturan-backup-write',
+            'pengaturan-backup-edit',
+            'pengaturan-backup-delete',
+        ])->delete();
+    }
+};

--- a/database/migrations/2026_07_03_000002_add_backup_permissions.php
+++ b/database/migrations/2026_07_03_000002_add_backup_permissions.php
@@ -9,10 +9,10 @@ return new class extends Migration
     public function up(): void
     {
         $permissions = [
-            'pengaturan-backup-read',
-            'pengaturan-backup-write',
-            'pengaturan-backup-edit',
-            'pengaturan-backup-delete',
+            'pengaturan-database-read',
+            'pengaturan-database-write',
+            'pengaturan-database-edit',
+            'pengaturan-database-delete',
         ];
 
         foreach ($permissions as $name) {
@@ -29,10 +29,10 @@ return new class extends Migration
     public function down(): void
     {
         Permission::whereIn('name', [
-            'pengaturan-backup-read',
-            'pengaturan-backup-write',
-            'pengaturan-backup-edit',
-            'pengaturan-backup-delete',
+            'pengaturan-database-read',
+            'pengaturan-database-write',
+            'pengaturan-database-edit',
+            'pengaturan-database-delete',
         ])->delete();
     }
 };

--- a/lang/vendor/backup/ar/notifications.php
+++ b/lang/vendor/backup/ar/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'رسالة استثناء: :message',
+    'exception_trace' => 'تتبع الإستثناء: :trace',
+    'exception_message_title' => 'رسالة استثناء',
+    'exception_trace_title' => 'تتبع الإستثناء',
+
+    'backup_failed_subject' => 'أخفق النسخ الاحتياطي لل :application_name',
+    'backup_failed_body' => 'مهم: حدث خطأ أثناء النسخ الاحتياطي :application_name',
+
+    'backup_successful_subject' => 'نسخ احتياطي جديد ناجح ل :application_name',
+    'backup_successful_subject_title' => 'نجاح النسخ الاحتياطي الجديد!',
+    'backup_successful_body' => 'أخبار عظيمة، نسخة احتياطية جديدة ل :application_name تم إنشاؤها بنجاح على القرص المسمى :disk_name.',
+
+    'cleanup_failed_subject' => 'فشل تنظيف النسخ الاحتياطي للتطبيق :application_name .',
+    'cleanup_failed_body' => 'حدث خطأ أثناء تنظيف النسخ الاحتياطية ل :application_name',
+
+    'cleanup_successful_subject' => 'تنظيف النسخ الاحتياطية ل :application_name تمت بنجاح',
+    'cleanup_successful_subject_title' => 'تنظيف النسخ الاحتياطية تم بنجاح!',
+    'cleanup_successful_body' => 'تنظيف النسخ الاحتياطية ل :application_name على القرص المسمى :disk_name تم بنجاح.',
+
+    'healthy_backup_found_subject' => 'النسخ الاحتياطية ل :application_name على القرص :disk_name صحية',
+    'healthy_backup_found_subject_title' => 'النسخ الاحتياطية ل :application_name صحية',
+    'healthy_backup_found_body' => 'تعتبر النسخ الاحتياطية ل :application_name صحية. عمل جيد!',
+
+    'unhealthy_backup_found_subject' => 'مهم: النسخ الاحتياطية ل :application_name غير صحية',
+    'unhealthy_backup_found_subject_title' => 'مهم: النسخ الاحتياطية ل :application_name غير صحية. :problem',
+    'unhealthy_backup_found_body' => 'النسخ الاحتياطية ل :application_name على القرص :disk_name غير صحية.',
+    'unhealthy_backup_found_not_reachable' => 'لا يمكن الوصول إلى وجهة النسخ الاحتياطي. :error',
+    'unhealthy_backup_found_empty' => 'لا توجد نسخ احتياطية لهذا التطبيق على الإطلاق.',
+    'unhealthy_backup_found_old' => 'تم إنشاء أحدث النسخ الاحتياطية في :date وتعتبر قديمة جدا.',
+    'unhealthy_backup_found_unknown' => 'عذرا، لا يمكن تحديد سبب دقيق.',
+    'unhealthy_backup_found_full' => 'النسخ الاحتياطية تستخدم الكثير من التخزين. الاستخدام الحالي هو :disk_usage وهو أعلى من الحد المسموح به من :disk_limit.',
+
+    'no_backups_info' => 'لم يتم عمل نسخ احتياطية حتى الآن',
+    'application_name' => 'اسم التطبيق',
+    'backup_name' => 'اسم النسخ الاحتياطي',
+    'disk' => 'القرص',
+    'newest_backup_size' => 'أحدث حجم للنسخ الاحتياطي',
+    'number_of_backups' => 'عدد النسخ الاحتياطية',
+    'total_storage_used' => 'إجمالي مساحة التخزين المستخدمة',
+    'newest_backup_date' => 'أحدث تاريخ النسخ الاحتياطي',
+    'oldest_backup_date' => 'أقدم تاريخ نسخ احتياطي',
+];

--- a/lang/vendor/backup/bg/notifications.php
+++ b/lang/vendor/backup/bg/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Съобщение за изключение: :message',
+    'exception_trace' => 'Проследяване на изключение: :trace',
+    'exception_message_title' => 'Съобщение за изключение',
+    'exception_trace_title' => 'Проследяване на изключение',
+
+    'backup_failed_subject' => 'Неуспешно резервно копие на :application_name',
+    'backup_failed_body' => 'Важно: Възникна грешка при архивиране на :application_name',
+
+    'backup_successful_subject' => 'Успешно ново резервно копие на :application_name',
+    'backup_successful_subject_title' => 'Успешно ново резервно копие!',
+    'backup_successful_body' => 'Чудесни новини, ново резервно копие на :application_name беше успешно създадено на диска с име :disk_name.',
+
+    'cleanup_failed_subject' => 'Почистването на резервните копия на :application_name не бе успешно.',
+    'cleanup_failed_body' => 'Възникна грешка при почистването на резервните копия на :application_name',
+
+    'cleanup_successful_subject' => 'Почистването на архивите на :application_name е успешно',
+    'cleanup_successful_subject_title' => 'Почистването на резервните копия е успешно!',
+    'cleanup_successful_body' => 'Почистването на резервни копия на :application_name на диска с име :disk_name беше успешно.',
+
+    'healthy_backup_found_subject' => 'Резервните копия за :application_name на диск :disk_name са здрави',
+    'healthy_backup_found_subject_title' => 'Резервните копия за :application_name са здрави',
+    'healthy_backup_found_body' => 'Резервните копия за :application_name се считат за здрави. Добра работа!',
+
+    'unhealthy_backup_found_subject' => 'Важно: Резервните копия за :application_name не са здрави',
+    'unhealthy_backup_found_subject_title' => 'Важно: Резервните копия за :application_name не са здрави. :проблем',
+    'unhealthy_backup_found_body' => 'Резервните копия за :application_name на диск :disk_name не са здрави.',
+    'unhealthy_backup_found_not_reachable' => 'Дестинацията за резервни копия не може да бъде достигната. :грешка',
+    'unhealthy_backup_found_empty' => 'Изобщо няма резервни копия на това приложение.',
+    'unhealthy_backup_found_old' => 'Последното резервно копие, направено на :date, се счита за твърде старо.',
+    'unhealthy_backup_found_unknown' => 'За съжаление не може да се определи точна причина.',
+    'unhealthy_backup_found_full' => 'Резервните копия използват твърде много място за съхранение. Текущото използване е :disk_usage, което е по-високо от разрешеното ограничение на :disk_limit.',
+
+    'no_backups_info' => 'Все още не са правени резервни копия',
+    'application_name' => 'Име на приложението',
+    'backup_name' => 'Име на резервно копие',
+    'disk' => 'Диск',
+    'newest_backup_size' => 'Най-новият размер на резервно копие',
+    'number_of_backups' => 'Брой резервни копия',
+    'total_storage_used' => 'Общо използвано дисково пространство',
+    'newest_backup_date' => 'Най-нова дата на резервно копие',
+    'oldest_backup_date' => 'Най-старата дата на резервно копие',
+];

--- a/lang/vendor/backup/bn/notifications.php
+++ b/lang/vendor/backup/bn/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'এক্সসেপশন বার্তা: :message',
+    'exception_trace' => 'এক্সসেপশন ট্রেস: :trace',
+    'exception_message_title' => 'এক্সসেপশন message',
+    'exception_trace_title' => 'এক্সসেপশন ট্রেস',
+
+    'backup_failed_subject' => ':application_name এর ব্যাকআপ ব্যর্থ হয়েছে।',
+    'backup_failed_body' => 'গুরুত্বপূর্ণঃ :application_name ব্যাক আপ করার সময় একটি ত্রুটি ঘটেছে।',
+
+    'backup_successful_subject' => ':application_name এর নতুন ব্যাকআপ সফল হয়েছে।',
+    'backup_successful_subject_title' => 'নতুন ব্যাকআপ সফল হয়েছে!',
+    'backup_successful_body' => 'খুশির খবর, :application_name এর নতুন ব্যাকআপ :disk_name ডিস্কে সফলভাবে তৈরি হয়েছে।',
+
+    'cleanup_failed_subject' => ':application_name ব্যাকআপগুলি সাফ করতে ব্যর্থ হয়েছে।',
+    'cleanup_failed_body' => ':application_name ব্যাকআপগুলি সাফ করার সময় একটি ত্রুটি ঘটেছে।',
+
+    'cleanup_successful_subject' => ':application_name এর ব্যাকআপগুলি সফলভাবে সাফ করা হয়েছে।',
+    'cleanup_successful_subject_title' => 'ব্যাকআপগুলি সফলভাবে সাফ করা হয়েছে!',
+    'cleanup_successful_body' => ':application_name এর ব্যাকআপগুলি :disk_name ডিস্ক থেকে সফলভাবে সাফ করা হয়েছে।',
+
+    'healthy_backup_found_subject' => ':application_name এর ব্যাকআপগুলি :disk_name ডিস্কে স্বাস্থ্যকর অবস্থায় আছে।',
+    'healthy_backup_found_subject_title' => ':application_name এর ব্যাকআপগুলি স্বাস্থ্যকর অবস্থায় আছে।',
+    'healthy_backup_found_body' => ':application_name এর ব্যাকআপগুলি  স্বাস্থ্যকর বিবেচনা করা হচ্ছে। Good job!',
+
+    'unhealthy_backup_found_subject' => 'গুরুত্বপূর্ণঃ :application_name এর ব্যাকআপগুলি অস্বাস্থ্যকর অবস্থায় আছে।',
+    'unhealthy_backup_found_subject_title' => 'গুরুত্বপূর্ণঃ :application_name এর ব্যাকআপগুলি অস্বাস্থ্যকর অবস্থায় আছে। :problem',
+    'unhealthy_backup_found_body' => ':disk_name ডিস্কের :application_name এর ব্যাকআপগুলি অস্বাস্থ্যকর অবস্থায় আছে।',
+    'unhealthy_backup_found_not_reachable' => 'ব্যাকআপ গন্তব্যে পৌঁছানো যায় নি। :error',
+    'unhealthy_backup_found_empty' => 'এই অ্যাপ্লিকেশনটির কোনও ব্যাকআপ নেই।',
+    'unhealthy_backup_found_old' => 'সর্বশেষ ব্যাকআপ যেটি :date এই তারিখে করা হয়েছে, সেটি খুব পুরানো।',
+    'unhealthy_backup_found_unknown' => 'দুঃখিত, সঠিক কারণ নির্ধারণ করা সম্ভব হয়নি।',
+    'unhealthy_backup_found_full' => 'ব্যাকআপগুলি অতিরিক্ত স্টোরেজ ব্যবহার করছে। বর্তমান ব্যবহারের পরিমান :disk_usage যা অনুমোদিত সীমা :disk_limit এর বেশি।',
+
+    'no_backups_info' => 'কোনো ব্যাকআপ এখনও তৈরি হয়নি',
+    'application_name' => 'আবেদনের নাম',
+    'backup_name' => 'ব্যাকআপের নাম',
+    'disk' => 'ডিস্ক',
+    'newest_backup_size' => 'নতুন ব্যাকআপ আকার',
+    'number_of_backups' => 'ব্যাকআপের সংখ্যা',
+    'total_storage_used' => 'ব্যবহৃত মোট সঞ্চয়স্থান',
+    'newest_backup_date' => 'নতুন ব্যাকআপের তারিখ',
+    'oldest_backup_date' => 'পুরানো ব্যাকআপের তারিখ',
+];

--- a/lang/vendor/backup/cs/notifications.php
+++ b/lang/vendor/backup/cs/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Zpráva výjimky: :message',
+    'exception_trace' => 'Stopa výjimky: :trace',
+    'exception_message_title' => 'Zpráva výjimky',
+    'exception_trace_title' => 'Stopa výjimky',
+
+    'backup_failed_subject' => 'Záloha :application_name neuspěla',
+    'backup_failed_body' => 'Důležité: Při záloze :application_name se vyskytla chyba',
+
+    'backup_successful_subject' => 'Úspěšná nová záloha :application_name',
+    'backup_successful_subject_title' => 'Úspěšná nová záloha!',
+    'backup_successful_body' => 'Dobrá zpráva, na disku jménem :disk_name byla úspěšně vytvořena nová záloha :application_name.',
+
+    'cleanup_failed_subject' => 'Vyčištění záloh :application_name neuspělo.',
+    'cleanup_failed_body' => 'Při čištění záloh :application_name se vyskytla chyba',
+
+    'cleanup_successful_subject' => 'Vyčištění záloh :application_name úspěšné',
+    'cleanup_successful_subject_title' => 'Vyčištění záloh bylo úspěšné!',
+    'cleanup_successful_body' => 'Vyčištění záloh :application_name na disku jménem :disk_name bylo úspěšné.',
+
+    'healthy_backup_found_subject' => 'Zálohy pro :application_name na disku :disk_name jsou zdravé',
+    'healthy_backup_found_subject_title' => 'Zálohy pro :application_name jsou zdravé',
+    'healthy_backup_found_body' => 'Zálohy pro :application_name jsou považovány za zdravé. Dobrá práce!',
+
+    'unhealthy_backup_found_subject' => 'Důležité: Zálohy pro :application_name jsou nezdravé',
+    'unhealthy_backup_found_subject_title' => 'Důležité: Zálohy pro :application_name jsou nezdravé. :problem',
+    'unhealthy_backup_found_body' => 'Zálohy pro :application_name na disku :disk_name jsou nezdravé.',
+    'unhealthy_backup_found_not_reachable' => 'Nelze se dostat k cíli zálohy. :error',
+    'unhealthy_backup_found_empty' => 'Tato aplikace nemá vůbec žádné zálohy.',
+    'unhealthy_backup_found_old' => 'Poslední záloha vytvořená dne :date je považována za příliš starou.',
+    'unhealthy_backup_found_unknown' => 'Omlouváme se, nemůžeme určit přesný důvod.',
+    'unhealthy_backup_found_full' => 'Zálohy zabírají příliš mnoho místa na disku. Aktuální využití disku je :disk_usage, což je vyšší než povolený limit :disk_limit.',
+
+    'no_backups_info' => 'Zatím nebyly vytvořeny žádné zálohy',
+    'application_name' => 'Název aplikace',
+    'backup_name' => 'Název zálohy',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Velikost nejnovější zálohy',
+    'number_of_backups' => 'Počet záloh',
+    'total_storage_used' => 'Celková využitá kapacita úložiště',
+    'newest_backup_date' => 'Datum nejnovější zálohy',
+    'oldest_backup_date' => 'Datum nejstarší zálohy',
+];

--- a/lang/vendor/backup/da/notifications.php
+++ b/lang/vendor/backup/da/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Fejlbesked: :message',
+    'exception_trace' => 'Fejl trace: :trace',
+    'exception_message_title' => 'Fejlbesked',
+    'exception_trace_title' => 'Fejl trace',
+
+    'backup_failed_subject' => 'Backup af :application_name fejlede',
+    'backup_failed_body' => 'Vigtigt: Der skete en fejl under backup af :application_name',
+
+    'backup_successful_subject' => 'Ny backup af :application_name oprettet',
+    'backup_successful_subject_title' => 'Ny backup!',
+    'backup_successful_body' => 'Gode nyheder - der blev oprettet en ny backup af :application_name på disken :disk_name.',
+
+    'cleanup_failed_subject' => 'Oprydning af backups for :application_name fejlede.',
+    'cleanup_failed_body' => 'Der skete en fejl under oprydning af backups for :application_name',
+
+    'cleanup_successful_subject' => 'Oprydning af backups for :application_name gennemført',
+    'cleanup_successful_subject_title' => 'Backup oprydning gennemført!',
+    'cleanup_successful_body' => 'Oprydningen af backups for :application_name på disken :disk_name er gennemført.',
+
+    'healthy_backup_found_subject' => 'Alle backups for :application_name på disken :disk_name er OK',
+    'healthy_backup_found_subject_title' => 'Alle backups for :application_name er OK',
+    'healthy_backup_found_body' => 'Alle backups for :application_name er ok. Godt gået!',
+
+    'unhealthy_backup_found_subject' => 'Vigtigt: Backups for :application_name fejlbehæftede',
+    'unhealthy_backup_found_subject_title' => 'Vigtigt: Backups for :application_name er fejlbehæftede. :problem',
+    'unhealthy_backup_found_body' => 'Backups for :application_name på disken :disk_name er fejlbehæftede.',
+    'unhealthy_backup_found_not_reachable' => 'Backup destinationen kunne ikke findes. :error',
+    'unhealthy_backup_found_empty' => 'Denne applikation har ingen backups overhovedet.',
+    'unhealthy_backup_found_old' => 'Den seneste backup fra :date er for gammel.',
+    'unhealthy_backup_found_unknown' => 'Beklager, en præcis årsag kunne ikke findes.',
+    'unhealthy_backup_found_full' => 'Backups bruger for meget plads. Nuværende disk forbrug er :disk_usage, hvilket er mere end den tilladte grænse på :disk_limit.',
+
+    'no_backups_info' => 'Der blev ikke foretaget nogen sikkerhedskopier endnu',
+    'application_name' => 'Applikationens navn',
+    'backup_name' => 'Backup navn',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Nyeste backup-størrelse',
+    'number_of_backups' => 'Antal sikkerhedskopier',
+    'total_storage_used' => 'Samlet lagerplads brugt',
+    'newest_backup_date' => 'Nyeste backup-størrelse',
+    'oldest_backup_date' => 'Ældste backup-størrelse',
+];

--- a/lang/vendor/backup/de/notifications.php
+++ b/lang/vendor/backup/de/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Fehlermeldung: :message',
+    'exception_trace' => 'Fehlerverfolgung: :trace',
+    'exception_message_title' => 'Fehlermeldung',
+    'exception_trace_title' => 'Fehlerverfolgung',
+
+    'backup_failed_subject' => 'Backup von :application_name konnte nicht erstellt werden',
+    'backup_failed_body' => 'Wichtig: Beim Backup von :application_name ist ein Fehler aufgetreten',
+
+    'backup_successful_subject' => 'Erfolgreiches neues Backup von :application_name',
+    'backup_successful_subject_title' => 'Erfolgreiches neues Backup!',
+    'backup_successful_body' => 'Gute Nachrichten, ein neues Backup von :application_name wurde erfolgreich erstellt und in :disk_name gespeichert.',
+
+    'cleanup_failed_subject' => 'Aufräumen der Backups von :application_name schlug fehl.',
+    'cleanup_failed_body' => 'Beim aufräumen der Backups von :application_name ist ein Fehler aufgetreten',
+
+    'cleanup_successful_subject' => 'Aufräumen der Backups von :application_name backups erfolgreich',
+    'cleanup_successful_subject_title' => 'Aufräumen der Backups erfolgreich!',
+    'cleanup_successful_body' => 'Aufräumen der Backups von :application_name in :disk_name war erfolgreich.',
+
+    'healthy_backup_found_subject' => 'Die Backups von :application_name in :disk_name sind gesund',
+    'healthy_backup_found_subject_title' => 'Die Backups von :application_name sind gesund',
+    'healthy_backup_found_body' => 'Die Backups von :application_name wurden als gesund eingestuft. Gute Arbeit!',
+
+    'unhealthy_backup_found_subject' => 'Wichtig: Die Backups für :application_name sind nicht gesund',
+    'unhealthy_backup_found_subject_title' => 'Wichtig: Die Backups für :application_name sind ungesund. :problem',
+    'unhealthy_backup_found_body' => 'Die Backups für :application_name in :disk_name sind ungesund.',
+    'unhealthy_backup_found_not_reachable' => 'Das Backup Ziel konnte nicht erreicht werden. :error',
+    'unhealthy_backup_found_empty' => 'Es gibt für die Anwendung noch gar keine Backups.',
+    'unhealthy_backup_found_old' => 'Das letzte Backup am :date ist zu lange her.',
+    'unhealthy_backup_found_unknown' => 'Sorry, ein genauer Grund konnte nicht gefunden werden.',
+    'unhealthy_backup_found_full' => 'Die Backups verbrauchen zu viel Platz. Aktuell wird :disk_usage belegt, das ist höher als das erlaubte Limit von :disk_limit.',
+
+    'no_backups_info' => 'Bisher keine Backups vorhanden',
+    'application_name' => 'Applikationsname',
+    'backup_name' => 'Backup Name',
+    'disk' => 'Speicherort',
+    'newest_backup_size' => 'Neuste Backup-Größe',
+    'number_of_backups' => 'Anzahl Backups',
+    'total_storage_used' => 'Gesamter genutzter Speicherplatz',
+    'newest_backup_date' => 'Neustes Backup',
+    'oldest_backup_date' => 'Ältestes Backup',
+];

--- a/lang/vendor/backup/en/notifications.php
+++ b/lang/vendor/backup/en/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Exception message: :message',
+    'exception_trace' => 'Exception trace: :trace',
+    'exception_message_title' => 'Exception message',
+    'exception_trace_title' => 'Exception trace',
+
+    'backup_failed_subject' => 'Failed backup of :application_name',
+    'backup_failed_body' => 'Important: An error occurred while backing up :application_name',
+
+    'backup_successful_subject' => 'Successful new backup of :application_name',
+    'backup_successful_subject_title' => 'Successful new backup!',
+    'backup_successful_body' => 'Great news, a new backup of :application_name was successfully created on the disk named :disk_name.',
+
+    'cleanup_failed_subject' => 'Cleaning up the backups of :application_name failed.',
+    'cleanup_failed_body' => 'An error occurred while cleaning up the backups of :application_name',
+
+    'cleanup_successful_subject' => 'Clean up of :application_name backups successful',
+    'cleanup_successful_subject_title' => 'Clean up of backups successful!',
+    'cleanup_successful_body' => 'The clean up of the :application_name backups on the disk named :disk_name was successful.',
+
+    'healthy_backup_found_subject' => 'The backups for :application_name on disk :disk_name are healthy',
+    'healthy_backup_found_subject_title' => 'The backups for :application_name are healthy',
+    'healthy_backup_found_body' => 'The backups for :application_name are considered healthy. Good job!',
+
+    'unhealthy_backup_found_subject' => 'Important: The backups for :application_name are unhealthy',
+    'unhealthy_backup_found_subject_title' => 'Important: The backups for :application_name are unhealthy. :problem',
+    'unhealthy_backup_found_body' => 'The backups for :application_name on disk :disk_name are unhealthy.',
+    'unhealthy_backup_found_not_reachable' => 'The backup destination cannot be reached. :error',
+    'unhealthy_backup_found_empty' => 'There are no backups of this application at all.',
+    'unhealthy_backup_found_old' => 'The latest backup made on :date is considered too old.',
+    'unhealthy_backup_found_unknown' => 'Sorry, an exact reason cannot be determined.',
+    'unhealthy_backup_found_full' => 'The backups are using too much storage. Current usage is :disk_usage which is higher than the allowed limit of :disk_limit.',
+
+    'no_backups_info' => 'No backups were made yet',
+    'application_name' => 'Application name',
+    'backup_name' => 'Backup name',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Newest backup size',
+    'number_of_backups' => 'Number of backups',
+    'total_storage_used' => 'Total storage used',
+    'newest_backup_date' => 'Newest backup date',
+    'oldest_backup_date' => 'Oldest backup date',
+];

--- a/lang/vendor/backup/es/notifications.php
+++ b/lang/vendor/backup/es/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Mensaje de la excepción: :message',
+    'exception_trace' => 'Traza de la excepción: :trace',
+    'exception_message_title' => 'Mensaje de la excepción',
+    'exception_trace_title' => 'Traza de la excepción',
+
+    'backup_failed_subject' => 'Copia de seguridad de :application_name fallida',
+    'backup_failed_body' => 'Importante: Ocurrió un error al realizar la copia de seguridad de :application_name',
+
+    'backup_successful_subject' => 'Se completó con éxito la copia de seguridad de :application_name',
+    'backup_successful_subject_title' => '¡Nueva copia de seguridad creada con éxito!',
+    'backup_successful_body' => 'Buenas noticias, una nueva copia de seguridad de :application_name fue creada con éxito en el disco llamado :disk_name.',
+
+    'cleanup_failed_subject' => 'La limpieza de copias de seguridad de :application_name falló.',
+    'cleanup_failed_body' => 'Ocurrió un error mientras se realizaba la limpieza de copias de seguridad de :application_name',
+
+    'cleanup_successful_subject' => 'La limpieza de copias de seguridad de :application_name se completó con éxito',
+    'cleanup_successful_subject_title' => '!Limpieza de copias de seguridad completada con éxito!',
+    'cleanup_successful_body' => 'La limpieza de copias de seguridad de :application_name en el disco llamado :disk_name se completo con éxito.',
+
+    'healthy_backup_found_subject' => 'Las copias de seguridad de :application_name en el disco :disk_name están en buen estado',
+    'healthy_backup_found_subject_title' => 'Las copias de seguridad de :application_name están en buen estado',
+    'healthy_backup_found_body' => 'Las copias de seguridad de :application_name se consideran en buen estado. ¡Buen trabajo!',
+
+    'unhealthy_backup_found_subject' => 'Importante: Las copias de seguridad de :application_name están en mal estado',
+    'unhealthy_backup_found_subject_title' => 'Importante: Las copias de seguridad de :application_name están en mal estado. :problem',
+    'unhealthy_backup_found_body' => 'Las copias de seguridad de :application_name en el disco :disk_name están en mal estado.',
+    'unhealthy_backup_found_not_reachable' => 'No se puede acceder al destino de la copia de seguridad. :error',
+    'unhealthy_backup_found_empty' => 'No existe ninguna copia de seguridad de esta aplicación.',
+    'unhealthy_backup_found_old' => 'La última copia de seguriad hecha en :date es demasiado antigua.',
+    'unhealthy_backup_found_unknown' => 'Lo siento, no es posible determinar la razón exacta.',
+    'unhealthy_backup_found_full' => 'Las copias de seguridad están ocupando demasiado espacio. El espacio utilizado actualmente es :disk_usage el cual es mayor que el límite permitido de :disk_limit.',
+
+    'no_backups_info' => 'Aún no se hicieron copias de seguridad',
+    'application_name' => 'Nombre de la aplicación',
+    'backup_name' => 'Nombre de la copia de seguridad',
+    'disk' => 'Disco',
+    'newest_backup_size' => 'Tamaño de copia de seguridad más reciente',
+    'number_of_backups' => 'Número de copias de seguridad',
+    'total_storage_used' => 'Almacenamiento total utilizado',
+    'newest_backup_date' => 'Fecha de la copia de seguridad más reciente',
+    'oldest_backup_date' => 'Fecha de la copia de seguridad más antigua',
+];

--- a/lang/vendor/backup/fa/notifications.php
+++ b/lang/vendor/backup/fa/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'پیغام خطا: :message',
+    'exception_trace' => 'جزییات خطا: :trace',
+    'exception_message_title' => 'پیغام خطا',
+    'exception_trace_title' => 'جزییات خطا',
+
+    'backup_failed_subject' => 'پشتیبان‌گیری :application_name با خطا مواجه شد.',
+    'backup_failed_body' => 'پیغام مهم: هنگام پشتیبان‌گیری از :application_name خطایی رخ داده است. ',
+
+    'backup_successful_subject' => 'نسخه پشتیبان جدید :application_name با موفقیت ساخته شد.',
+    'backup_successful_subject_title' => 'پشتیبان‌گیری موفق!',
+    'backup_successful_body' => 'خبر خوب، به تازگی نسخه پشتیبان :application_name روی دیسک :disk_name با موفقیت ساخته شد. ',
+
+    'cleanup_failed_subject' => 'پاک‌‌سازی نسخه پشتیبان :application_name انجام نشد.',
+    'cleanup_failed_body' => 'هنگام پاک‌سازی نسخه پشتیبان :application_name خطایی رخ داده است.',
+
+    'cleanup_successful_subject' => 'پاک‌سازی نسخه پشتیبان :application_name با موفقیت انجام شد.',
+    'cleanup_successful_subject_title' => 'پاک‌سازی نسخه پشتیبان!',
+    'cleanup_successful_body' => 'پاک‌سازی نسخه پشتیبان :application_name روی دیسک :disk_name با موفقیت انجام شد.',
+
+    'healthy_backup_found_subject' => 'نسخه پشتیبان :application_name روی دیسک :disk_name سالم بود.',
+    'healthy_backup_found_subject_title' => 'نسخه پشتیبان :application_name سالم بود.',
+    'healthy_backup_found_body' => 'نسخه پشتیبان :application_name به نظر سالم میاد. دمت گرم!',
+
+    'unhealthy_backup_found_subject' => 'خبر مهم: نسخه پشتیبان :application_name سالم نبود.',
+    'unhealthy_backup_found_subject_title' => 'خبر مهم: نسخه پشتیبان :application_name سالم نبود. :problem',
+    'unhealthy_backup_found_body' => 'نسخه پشتیبان :application_name روی دیسک :disk_name سالم نبود.',
+    'unhealthy_backup_found_not_reachable' => 'مقصد پشتیبان‌گیری در دسترس نبود. :error',
+    'unhealthy_backup_found_empty' => 'برای این برنامه هیچ نسخه پشتیبانی وجود ندارد.',
+    'unhealthy_backup_found_old' => 'آخرین نسخه پشتیبان برای تاریخ :date است، که به نظر خیلی قدیمی میاد. ',
+    'unhealthy_backup_found_unknown' => 'متاسفانه دلیل دقیقی قابل تعیین نیست.',
+    'unhealthy_backup_found_full' => 'نسخه‌های پشتیبان حجم زیادی اشغال کرده‌اند. میزان دیسک استفاده‌شده :disk_usage است که از میزان مجاز :disk_limit فراتر رفته است. ',
+
+    'no_backups_info' => 'هنوز نسخه پشتیبان تهیه نشده است',
+    'application_name' => 'نام نرم‌افزار',
+    'backup_name' => 'نام نسخه پشتیبان',
+    'disk' => 'دیسک',
+    'newest_backup_size' => 'اندازه جدیدترین نسخه پشتیبان',
+    'number_of_backups' => 'تعداد نسخه‌های پشتیبان',
+    'total_storage_used' => 'کل فضای ذخیره‌سازی استفاده‌شده',
+    'newest_backup_date' => 'تاریخ جدیدترین نسخه پشتیبان',
+    'oldest_backup_date' => 'تاریخ قدیمی‌ترین نسخه پشتیبان',
+];

--- a/lang/vendor/backup/fi/notifications.php
+++ b/lang/vendor/backup/fi/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Virheilmoitus: :message',
+    'exception_trace' => 'Virhe, jäljitys: :trace',
+    'exception_message_title' => 'Virheilmoitus',
+    'exception_trace_title' => 'Virheen jäljitys',
+
+    'backup_failed_subject' => ':application_name varmuuskopiointi epäonnistui',
+    'backup_failed_body' => 'HUOM!: :application_name varmuuskoipionnissa tapahtui virhe',
+
+    'backup_successful_subject' => ':application_name varmuuskopioitu onnistuneesti',
+    'backup_successful_subject_title' => 'Uusi varmuuskopio!',
+    'backup_successful_body' => 'Hyviä uutisia! :application_name on varmuuskopioitu levylle :disk_name.',
+
+    'cleanup_failed_subject' => ':application_name varmuuskopioiden poistaminen epäonnistui.',
+    'cleanup_failed_body' => ':application_name varmuuskopioiden poistamisessa tapahtui virhe.',
+
+    'cleanup_successful_subject' => ':application_name varmuuskopiot poistettu onnistuneesti',
+    'cleanup_successful_subject_title' => 'Varmuuskopiot poistettu onnistuneesti!',
+    'cleanup_successful_body' => ':application_name varmuuskopiot poistettu onnistuneesti levyltä :disk_name.',
+
+    'healthy_backup_found_subject' => ':application_name varmuuskopiot levyllä :disk_name ovat kunnossa',
+    'healthy_backup_found_subject_title' => ':application_name varmuuskopiot ovat kunnossa',
+    'healthy_backup_found_body' => ':application_name varmuuskopiot ovat kunnossa. Hieno homma!',
+
+    'unhealthy_backup_found_subject' => 'HUOM!: :application_name varmuuskopiot ovat vialliset',
+    'unhealthy_backup_found_subject_title' => 'HUOM!: :application_name varmuuskopiot ovat vialliset. :problem',
+    'unhealthy_backup_found_body' => ':application_name varmuuskopiot levyllä :disk_name ovat vialliset.',
+    'unhealthy_backup_found_not_reachable' => 'Varmuuskopioiden kohdekansio ei ole saatavilla. :error',
+    'unhealthy_backup_found_empty' => 'Tästä sovelluksesta ei ole varmuuskopioita.',
+    'unhealthy_backup_found_old' => 'Viimeisin varmuuskopio, luotu :date, on liian vanha.',
+    'unhealthy_backup_found_unknown' => 'Virhe, tarkempaa tietoa syystä ei valitettavasti ole saatavilla.',
+    'unhealthy_backup_found_full' => 'Varmuuskopiot vievät liikaa levytilaa. Tällä hetkellä käytössä :disk_usage, mikä on suurempi kuin sallittu tilavuus (:disk_limit).',
+
+    'no_backups_info' => 'Varmuuskopioita ei vielä tehty',
+    'application_name' => 'Sovelluksen nimi',
+    'backup_name' => 'Varmuuskopion nimi',
+    'disk' => 'Levy',
+    'newest_backup_size' => 'Uusin varmuuskopion koko',
+    'number_of_backups' => 'Varmuuskopioiden määrä',
+    'total_storage_used' => 'Käytetty tallennustila yhteensä',
+    'newest_backup_date' => 'Uusin varmuuskopion koko',
+    'oldest_backup_date' => 'Vanhin varmuuskopion koko',
+];

--- a/lang/vendor/backup/fr/notifications.php
+++ b/lang/vendor/backup/fr/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => "Message de l'exception : :message",
+    'exception_trace' => "Trace de l'exception : :trace",
+    'exception_message_title' => "Message de l'exception",
+    'exception_trace_title' => "Trace de l'exception",
+
+    'backup_failed_subject' => 'Échec de la sauvegarde de :application_name',
+    'backup_failed_body' => 'Important : Une erreur est survenue lors de la sauvegarde de :application_name',
+
+    'backup_successful_subject' => 'Succès de la sauvegarde de :application_name',
+    'backup_successful_subject_title' => 'Sauvegarde créée avec succès !',
+    'backup_successful_body' => 'Bonne nouvelle, une nouvelle sauvegarde de :application_name a été créée avec succès sur le disque nommé :disk_name.',
+
+    'cleanup_failed_subject' => 'Le nettoyage des sauvegardes de :application_name a echoué.',
+    'cleanup_failed_body' => 'Une erreur est survenue lors du nettoyage des sauvegardes de :application_name',
+
+    'cleanup_successful_subject' => 'Succès du nettoyage des sauvegardes de :application_name',
+    'cleanup_successful_subject_title' => 'Sauvegardes nettoyées avec succès !',
+    'cleanup_successful_body' => 'Le nettoyage des sauvegardes de :application_name sur le disque nommé :disk_name a été effectué avec succès.',
+
+    'healthy_backup_found_subject' => 'Les sauvegardes pour :application_name sur le disque :disk_name sont saines',
+    'healthy_backup_found_subject_title' => 'Les sauvegardes pour :application_name sont saines',
+    'healthy_backup_found_body' => 'Les sauvegardes pour :application_name sont considérées saines. Bon travail !',
+
+    'unhealthy_backup_found_subject' => 'Important : Les sauvegardes pour :application_name sont corrompues',
+    'unhealthy_backup_found_subject_title' => 'Important : Les sauvegardes pour :application_name sont corrompues. :problem',
+    'unhealthy_backup_found_body' => 'Les sauvegardes pour :application_name sur le disque :disk_name sont corrompues.',
+    'unhealthy_backup_found_not_reachable' => "La destination de la sauvegarde n'est pas accessible. :error",
+    'unhealthy_backup_found_empty' => "Il n'y a aucune sauvegarde pour cette application.",
+    'unhealthy_backup_found_old' => 'La dernière sauvegarde du :date est considérée trop vieille.',
+    'unhealthy_backup_found_unknown' => 'Désolé, une raison exacte ne peut être déterminée.',
+    'unhealthy_backup_found_full' => 'Les sauvegardes utilisent trop d\'espace disque. L\'utilisation actuelle est de :disk_usage alors que la limite autorisée est de :disk_limit.',
+
+    'no_backups_info' => 'Aucune sauvegarde n\'a encore été effectuée',
+    'application_name' => "Nom de l'application",
+    'backup_name' => 'Nom de la sauvegarde',
+    'disk' => 'Disque',
+    'newest_backup_size' => 'Taille de la sauvegarde la plus récente',
+    'number_of_backups' => 'Nombre de sauvegardes',
+    'total_storage_used' => 'Stockage total utilisé',
+    'newest_backup_date' => 'Date de la sauvegarde la plus récente',
+    'oldest_backup_date' => 'Date de la sauvegarde la plus ancienne',
+];

--- a/lang/vendor/backup/he/notifications.php
+++ b/lang/vendor/backup/he/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'הודעת חריגה: :message',
+    'exception_trace' => 'מעקב חריגה: :trace',
+    'exception_message_title' => 'הודעת חריגה',
+    'exception_trace_title' => 'מעקב חריגה',
+
+    'backup_failed_subject' => 'כשל בגיבוי של :application_name',
+    'backup_failed_body' => 'חשוב: אירעה שגיאה במהלך גיבוי היישום :application_name',
+
+    'backup_successful_subject' => 'גיבוי חדש מוצלח של :application_name',
+    'backup_successful_subject_title' => 'גיבוי חדש מוצלח!',
+    'backup_successful_body' => 'חדשות טובות, גיבוי חדש של :application_name נוצר בהצלחה על הדיסק בשם :disk_name.',
+
+    'cleanup_failed_subject' => 'נכשל בניקוי הגיבויים של :application_name',
+    'cleanup_failed_body' => 'אירעה שגיאה במהלך ניקוי הגיבויים של :application_name',
+
+    'cleanup_successful_subject' => 'ניקוי הגיבויים של :application_name בוצע בהצלחה',
+    'cleanup_successful_subject_title' => 'ניקוי הגיבויים בוצע בהצלחה!',
+    'cleanup_successful_body' => 'ניקוי הגיבויים של :application_name על הדיסק בשם :disk_name בוצע בהצלחה.',
+
+    'healthy_backup_found_subject' => 'הגיבויים של :application_name על הדיסק :disk_name תקינים',
+    'healthy_backup_found_subject_title' => 'הגיבויים של :application_name תקינים',
+    'healthy_backup_found_body' => 'הגיבויים של :application_name נחשבים לתקינים. עבודה טובה!',
+
+    'unhealthy_backup_found_subject' => 'חשוב: הגיבויים של :application_name אינם תקינים',
+    'unhealthy_backup_found_subject_title' => 'חשוב: הגיבויים של :application_name אינם תקינים. :problem',
+    'unhealthy_backup_found_body' => 'הגיבויים של :application_name על הדיסק :disk_name אינם תקינים.',
+    'unhealthy_backup_found_not_reachable' => 'לא ניתן להגיע ליעד הגיבוי. :error',
+    'unhealthy_backup_found_empty' => 'אין גיבויים של היישום הזה בכלל.',
+    'unhealthy_backup_found_old' => 'הגיבוי האחרון שנעשה בתאריך :date נחשב כישן מדי.',
+    'unhealthy_backup_found_unknown' => 'מצטערים, לא ניתן לקבוע סיבה מדויקת.',
+    'unhealthy_backup_found_full' => 'הגיבויים משתמשים בשטח אחסון רב מידי. שימוש הנוכחי הוא :disk_usage, שגבול המותר הוא :disk_limit.',
+
+    'no_backups_info' => 'לא נעשו עדיין גיבויים',
+    'application_name' => 'שם היישום',
+    'backup_name' => 'שם הגיבוי',
+    'disk' => 'דיסק',
+    'newest_backup_size' => 'גודל הגיבוי החדש ביותר',
+    'number_of_backups' => 'מספר הגיבויים',
+    'total_storage_used' => 'סך האחסון המופעל',
+    'newest_backup_date' => 'תאריך הגיבוי החדש ביותר',
+    'oldest_backup_date' => 'תאריך הגיבוי הישן ביותר',
+];

--- a/lang/vendor/backup/hi/notifications.php
+++ b/lang/vendor/backup/hi/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'अपवाद संदेश: :message',
+    'exception_trace' => 'अपवाद निशान: :trace',
+    'exception_message_title' => 'अपवादी संदेश',
+    'exception_trace_title' => 'अपवाद निशान',
+
+    'backup_failed_subject' => ':application_name का बैकअप असफल रहा',
+    'backup_failed_body' => 'जरूरी सुचना: :application_name का बैकअप लेते समय असफल रहे',
+
+    'backup_successful_subject' => ':application_name का बैकअप सफल रहा',
+    'backup_successful_subject_title' => 'बैकअप सफल रहा!',
+    'backup_successful_body' => 'खुशखबर, :application_name का बैकअप :disk_name पर संग्रहित करने मे सफल रहे.',
+
+    'cleanup_failed_subject' => ':application_name के बैकअप की सफाई असफल रही.',
+    'cleanup_failed_body' => ':application_name के बैकअप की सफाई करते समय कुछ बाधा आयी है.',
+
+    'cleanup_successful_subject' => ':application_name के बैकअप की सफाई सफल रही',
+    'cleanup_successful_subject_title' => 'बैकअप की सफाई सफल रही!',
+    'cleanup_successful_body' => ':application_name का बैकअप जो :disk_name नाम की डिस्क पर संग्रहित है, उसकी सफाई सफल रही.',
+
+    'healthy_backup_found_subject' => ':disk_name नाम की डिस्क पर संग्रहित :application_name के बैकअप स्वस्थ है',
+    'healthy_backup_found_subject_title' => ':application_name के सभी बैकअप स्वस्थ है',
+    'healthy_backup_found_body' => 'बहुत बढ़िया! :application_name के सभी बैकअप स्वस्थ है.',
+
+    'unhealthy_backup_found_subject' => 'जरूरी सुचना :  :application_name के बैकअप अस्वस्थ है',
+    'unhealthy_backup_found_subject_title' => 'जरूरी सुचना : :application_name के बैकअप :problem के बजेसे अस्वस्थ है',
+    'unhealthy_backup_found_body' => ':disk_name नाम की डिस्क पर संग्रहित :application_name के बैकअप अस्वस्थ है',
+    'unhealthy_backup_found_not_reachable' => ':error के बजेसे बैकअप की मंजिल तक पोहोच नहीं सकते.',
+    'unhealthy_backup_found_empty' => 'इस एप्लीकेशन का कोई भी बैकअप नहीं है.',
+    'unhealthy_backup_found_old' => 'हालहीमें :date को लिया हुआ बैकअप बहुत पुराना है.',
+    'unhealthy_backup_found_unknown' => 'माफ़ कीजिये, सही कारण निर्धारित नहीं कर सकते.',
+    'unhealthy_backup_found_full' => 'सभी बैकअप बहुत ज्यादा जगह का उपयोग कर रहे है. फ़िलहाल सभी बैकअप :disk_usage जगह का उपयोग कर रहे है, जो की :disk_limit अनुमति सीमा से अधिक का है.',
+
+    'no_backups_info' => 'अभी तक कोई बैकअप नहीं बनाया गया था',
+    'application_name' => 'आवेदन का नाम',
+    'backup_name' => 'बैकअप नाम',
+    'disk' => 'डिस्क',
+    'newest_backup_size' => 'नवीनतम बैकअप आकार',
+    'number_of_backups' => 'बैकअप की संख्या',
+    'total_storage_used' => 'उपयोग किया गया कुल संग्रहण',
+    'newest_backup_date' => 'नवीनतम बैकअप आकार',
+    'oldest_backup_date' => 'सबसे पुराना बैकअप आकार',
+];

--- a/lang/vendor/backup/hr/notifications.php
+++ b/lang/vendor/backup/hr/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Greška: :message',
+    'exception_trace' => 'Praćenje greške: :trace',
+    'exception_message_title' => 'Greška',
+    'exception_trace_title' => 'Praćenje greške',
+
+    'backup_failed_subject' => 'Neuspješno sigurnosno kopiranje za :application_name',
+    'backup_failed_body' => 'Važno: Došlo je do greške prilikom sigurnosnog kopiranja za :application_name',
+
+    'backup_successful_subject' => 'Uspješno sigurnosno kopiranje za :application_name',
+    'backup_successful_subject_title' => 'Uspješno sigurnosno kopiranje!',
+    'backup_successful_body' => 'Nova sigurnosna kopija za :application_name je uspješno spremljena na disk :disk_name.',
+
+    'cleanup_failed_subject' => 'Neuspješno čišćenje sigurnosnih kopija za :application_name',
+    'cleanup_failed_body' => 'Došlo je do greške prilikom čišćenja sigurnosnih kopija za :application_name',
+
+    'cleanup_successful_subject' => 'Uspješno čišćenje sigurnosnih kopija za :application_name',
+    'cleanup_successful_subject_title' => 'Uspješno čišćenje sigurnosnih kopija!',
+    'cleanup_successful_body' => 'Sigurnosne kopije za :application_name su uspješno očišćene s diska :disk_name.',
+
+    'healthy_backup_found_subject' => 'Sigurnosne kopije za :application_name na disku :disk_name su zdrave',
+    'healthy_backup_found_subject_title' => 'Sigurnosne kopije za :application_name su zdrave',
+    'healthy_backup_found_body' => 'Sigurnosne kopije za :application_name se smatraju zdravima. Svaka čast!',
+
+    'unhealthy_backup_found_subject' => 'Važno: Sigurnosne kopije za :application_name su nezdrave',
+    'unhealthy_backup_found_subject_title' => 'Važno: Sigurnosne kopije za :application_name su nezdrave. :problem',
+    'unhealthy_backup_found_body' => 'Sigurnosne kopije za :application_name na disku :disk_name su nezdrave.',
+    'unhealthy_backup_found_not_reachable' => 'Destinacija sigurnosne kopije nije dohvatljiva. :error',
+    'unhealthy_backup_found_empty' => 'Nijedna sigurnosna kopija ove aplikacije ne postoji.',
+    'unhealthy_backup_found_old' => 'Zadnja sigurnosna kopija generirana na datum :date smatra se prestarom.',
+    'unhealthy_backup_found_unknown' => 'Isprike, ali nije moguće odrediti razlog.',
+    'unhealthy_backup_found_full' => 'Sigurnosne kopije zauzimaju previše prostora. Trenutno zauzeće je :disk_usage što je više od dozvoljenog ograničenja od :disk_limit.',
+
+    'no_backups_info' => 'Nema sigurnosnih kopija',
+    'application_name' => 'Naziv aplikacije',
+    'backup_name' => 'Naziv sigurnosne kopije',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Veličina najnovije sigurnosne kopije',
+    'number_of_backups' => 'Broj sigurnosnih kopija',
+    'total_storage_used' => 'Ukupno zauzeće',
+    'newest_backup_date' => 'Najnovija kopija na datum',
+    'oldest_backup_date' => 'Najstarija kopija na datum',
+];

--- a/lang/vendor/backup/id/notifications.php
+++ b/lang/vendor/backup/id/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Pesan pengecualian: :message',
+    'exception_trace' => 'Jejak pengecualian: :trace',
+    'exception_message_title' => 'Pesan pengecualian',
+    'exception_trace_title' => 'Jejak pengecualian',
+
+    'backup_failed_subject' => 'Gagal backup :application_name',
+    'backup_failed_body' => 'Penting: Sebuah error terjadi ketika membackup :application_name',
+
+    'backup_successful_subject' => 'Backup baru sukses dari :application_name',
+    'backup_successful_subject_title' => 'Backup baru sukses!',
+    'backup_successful_body' => 'Kabar baik, sebuah backup baru dari :application_name sukses dibuat pada disk bernama :disk_name.',
+
+    'cleanup_failed_subject' => 'Membersihkan backup dari :application_name yang gagal.',
+    'cleanup_failed_body' => 'Sebuah error teradi ketika membersihkan backup dari :application_name',
+
+    'cleanup_successful_subject' => 'Sukses membersihkan backup :application_name',
+    'cleanup_successful_subject_title' => 'Sukses membersihkan backup!',
+    'cleanup_successful_body' => 'Pembersihan backup :application_name pada disk bernama :disk_name telah sukses.',
+
+    'healthy_backup_found_subject' => 'Backup untuk :application_name pada disk :disk_name sehat',
+    'healthy_backup_found_subject_title' => 'Backup untuk :application_name sehat',
+    'healthy_backup_found_body' => 'Backup untuk :application_name dipertimbangkan sehat. Kerja bagus!',
+
+    'unhealthy_backup_found_subject' => 'Penting: Backup untuk :application_name tidak sehat',
+    'unhealthy_backup_found_subject_title' => 'Penting: Backup untuk :application_name tidak sehat. :problem',
+    'unhealthy_backup_found_body' => 'Backup untuk :application_name pada disk :disk_name tidak sehat.',
+    'unhealthy_backup_found_not_reachable' => 'Tujuan backup tidak dapat terjangkau. :error',
+    'unhealthy_backup_found_empty' => 'Tidak ada backup pada aplikasi ini sama sekali.',
+    'unhealthy_backup_found_old' => 'Backup terakhir dibuat pada :date dimana dipertimbahkan sudah sangat lama.',
+    'unhealthy_backup_found_unknown' => 'Maaf, sebuah alasan persisnya tidak dapat ditentukan.',
+    'unhealthy_backup_found_full' => 'Backup menggunakan terlalu banyak kapasitas penyimpanan. Penggunaan terkini adalah :disk_usage dimana lebih besar dari batas yang diperbolehkan yaitu :disk_limit.',
+
+    'no_backups_info' => 'Belum ada backup yang dibuat',
+    'application_name' => 'Nama aplikasi',
+    'backup_name' => 'Nama cadangan',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Ukuran cadangan terbaru',
+    'number_of_backups' => 'Jumlah cadangan',
+    'total_storage_used' => 'Total penyimpanan yang digunakan',
+    'newest_backup_date' => 'Ukuran cadangan terbaru',
+    'oldest_backup_date' => 'Ukuran cadangan tertua',
+];

--- a/lang/vendor/backup/it/notifications.php
+++ b/lang/vendor/backup/it/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => "Messaggio dell'eccezione: :message",
+    'exception_trace' => "Traccia dell'eccezione: :trace",
+    'exception_message_title' => "Messaggio dell'eccezione",
+    'exception_trace_title' => "Traccia dell'eccezione",
+
+    'backup_failed_subject' => 'Fallito il backup di :application_name',
+    'backup_failed_body' => 'Importante: Si è verificato un errore durante il backup di :application_name',
+
+    'backup_successful_subject' => 'Creato nuovo backup di :application_name',
+    'backup_successful_subject_title' => 'Nuovo backup creato!',
+    'backup_successful_body' => 'Grande notizia, un nuovo backup di :application_name è stato creato con successo sul disco :disk_name.',
+
+    'cleanup_failed_subject' => 'Pulizia dei backup di :application_name fallita.',
+    'cleanup_failed_body' => 'Si è verificato un errore durante la pulizia dei backup di :application_name',
+
+    'cleanup_successful_subject' => 'Pulizia dei backup di :application_name avvenuta con successo',
+    'cleanup_successful_subject_title' => 'Pulizia dei backup avvenuta con successo!',
+    'cleanup_successful_body' => 'La pulizia dei backup di :application_name sul disco :disk_name è avvenuta con successo.',
+
+    'healthy_backup_found_subject' => 'I backup per :application_name sul disco :disk_name sono sani',
+    'healthy_backup_found_subject_title' => 'I backup per :application_name sono sani',
+    'healthy_backup_found_body' => 'I backup per :application_name sono considerati sani. Bel Lavoro!',
+
+    'unhealthy_backup_found_subject' => 'Importante: i backup per :application_name sono corrotti',
+    'unhealthy_backup_found_subject_title' => 'Importante: i backup per :application_name sono corrotti. :problem',
+    'unhealthy_backup_found_body' => 'I backup per :application_name sul disco :disk_name sono corrotti.',
+    'unhealthy_backup_found_not_reachable' => 'Impossibile raggiungere la destinazione di backup. :error',
+    'unhealthy_backup_found_empty' => 'Non esiste alcun backup di questa applicazione.',
+    'unhealthy_backup_found_old' => 'L\'ultimo backup fatto il :date è considerato troppo vecchio.',
+    'unhealthy_backup_found_unknown' => 'Spiacenti, non è possibile determinare una ragione esatta.',
+    'unhealthy_backup_found_full' => 'I backup utilizzano troppa memoria. L\'utilizzo corrente è :disk_usage che è superiore al limite consentito di :disk_limit.',
+
+    'no_backups_info' => 'Non sono stati ancora effettuati backup',
+    'application_name' => "Nome dell'applicazione",
+    'backup_name' => 'Nome di backup',
+    'disk' => 'Disco',
+    'newest_backup_size' => 'Dimensione backup più recente',
+    'number_of_backups' => 'Numero di backup',
+    'total_storage_used' => 'Spazio di archiviazione totale utilizzato',
+    'newest_backup_date' => 'Data del backup più recente',
+    'oldest_backup_date' => 'Data del backup più vecchio',
+];

--- a/lang/vendor/backup/ja/notifications.php
+++ b/lang/vendor/backup/ja/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => '例外のメッセージ: :message',
+    'exception_trace' => '例外の追跡: :trace',
+    'exception_message_title' => '例外のメッセージ',
+    'exception_trace_title' => '例外の追跡',
+
+    'backup_failed_subject' => ':application_name のバックアップに失敗しました。',
+    'backup_failed_body' => '重要: :application_name のバックアップ中にエラーが発生しました。',
+
+    'backup_successful_subject' => ':application_name のバックアップに成功しました。',
+    'backup_successful_subject_title' => 'バックアップに成功しました！',
+    'backup_successful_body' => '朗報です。ディスク :disk_name へ :application_name のバックアップが成功しました。',
+
+    'cleanup_failed_subject' => ':application_name のバックアップ削除に失敗しました。',
+    'cleanup_failed_body' => ':application_name のバックアップ削除中にエラーが発生しました。',
+
+    'cleanup_successful_subject' => ':application_name のバックアップ削除に成功しました。',
+    'cleanup_successful_subject_title' => 'バックアップ削除に成功しました！',
+    'cleanup_successful_body' => 'ディスク :disk_name に保存された :application_name のバックアップ削除に成功しました。',
+
+    'healthy_backup_found_subject' => 'ディスク :disk_name への :application_name のバックアップは正常です。',
+    'healthy_backup_found_subject_title' => ':application_name のバックアップは正常です。',
+    'healthy_backup_found_body' => ':application_name へのバックアップは正常です。いい仕事してますね！',
+
+    'unhealthy_backup_found_subject' => '重要: :application_name のバックアップに異常があります。',
+    'unhealthy_backup_found_subject_title' => '重要: :application_name のバックアップに異常があります。 :problem',
+    'unhealthy_backup_found_body' => ':disk_name への :application_name のバックアップに異常があります。',
+    'unhealthy_backup_found_not_reachable' => 'バックアップ先にアクセスできませんでした。 :error',
+    'unhealthy_backup_found_empty' => 'このアプリケーションのバックアップは見つかりませんでした。',
+    'unhealthy_backup_found_old' => ':date に保存された直近のバックアップが古すぎます。',
+    'unhealthy_backup_found_unknown' => '申し訳ございません。予期せぬエラーです。',
+    'unhealthy_backup_found_full' => 'バックアップがディスク容量を圧迫しています。現在の使用量 :disk_usage　は、許可された限界値 :disk_limit を超えています。',
+
+    'no_backups_info' => 'バックアップはまだ作成されていません',
+    'application_name' => 'アプリケーション名',
+    'backup_name' => 'バックアップ名',
+    'disk' => 'ディスク',
+    'newest_backup_size' => '最新のバックアップサイズ',
+    'number_of_backups' => 'バックアップ数',
+    'total_storage_used' => '使用された合計ストレージ',
+    'newest_backup_date' => '最新のバックアップ日時',
+    'oldest_backup_date' => '最も古いバックアップ日時',
+];

--- a/lang/vendor/backup/kk/notifications.php
+++ b/lang/vendor/backup/kk/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Қате туралы хабарлама: :message',
+    'exception_trace' => 'Қате туралы мәліметтер: :trace',
+    'exception_message_title' => 'Қате туралы хабарлама',
+    'exception_trace_title' => 'Қате туралы мәліметтер',
+
+    'backup_failed_subject' => ':application_name бағдарламасының резервтік көшірмесін жасау сәтсіз аяқталды',
+    'backup_failed_body' => 'Маңызды: :application_name бағдарламасының резервтік көшірмесін жасау барысында қате орын алды',
+
+    'backup_successful_subject' => ':application_name бағдарламасының жаңа резервтік көшірмесі сәтті құрылды',
+    'backup_successful_subject_title' => 'Жаңа резервтік көшірме сәтті құрылды!',
+    'backup_successful_body' => 'Жақсы жаңалық: :application_name бағдарламасының жаңа резервтік көшірмесі :disk_name дискінде сәтті құрылды.',
+
+    'cleanup_failed_subject' => ':application_name бағдарламасының резервтік көшірмелерін тазалау сәтсіз аяқталды',
+    'cleanup_failed_body' => ':application_name бағдарламасының резервтік көшірмелерін тазалау барысында қате орын алды',
+
+    'cleanup_successful_subject' => ':application_name бағдарламасының резервтік көшірмелерін тазалау сәтті өтті',
+    'cleanup_successful_subject_title' => 'Резервтік көшірмелерді тазалау сәтті аяқталды!',
+    'cleanup_successful_body' => ':disk_name дискіндегі :application_name бағдарламасының резервтік көшірмелерін тазалау сәтті аяқталды.',
+
+    'healthy_backup_found_subject' => ':disk_name дискіндегі :application_name бағдарламасының резервтік көшірмелері қалыпты күйде',
+    'healthy_backup_found_subject_title' => ':application_name бағдарламасының резервтік көшірмелері қалыпты күйде',
+    'healthy_backup_found_body' => ':application_name бағдарламасының резервтік көшірмелері толық тексеруден өтті. Өте жақсы!',
+
+    'unhealthy_backup_found_subject' => 'Маңызды: :application_name бағдарламасының резервтік көшірмелері жарамсыз күйде',
+    'unhealthy_backup_found_subject_title' => 'Маңызды: :application_name бағдарламасының резервтік көшірмелері жарамсыз күйде. :problem',
+    'unhealthy_backup_found_body' => ':disk_name дискіндегі :application_name бағдарламасының резервтік көшірмелері жарамсыз күйде.',
+    'unhealthy_backup_found_not_reachable' => 'Резервтік көшірме сақтау орнына қол жеткізу мүмкін емес. :error',
+    'unhealthy_backup_found_empty' => 'Осы бағдарлама бойынша резервтік көшірмелер әлі жасалмаған.',
+    'unhealthy_backup_found_old' => 'Соңғы резервтік көшірме (:date) тым ескі болып саналады.',
+    'unhealthy_backup_found_unknown' => 'Кешіріңіз, нақты себебін анықтау мүмкін емес.',
+    'unhealthy_backup_found_full' => 'Резервтік көшірмелер тым көп орын алып отыр. Ағымдағы пайдалану көлемі :disk_usage, бұл рұқсат етілген шектен :disk_limit аса жоғары.',
+
+    'no_backups_info' => 'Әлі резервтік көшірме жасалмаған',
+    'application_name' => 'Бағдарлама атауы',
+    'backup_name' => 'Резервтік көшірме атауы',
+    'disk' => 'Диск',
+    'newest_backup_size' => 'Соңғы резервтік көшірменің көлемі',
+    'number_of_backups' => 'Резервтік көшірмелер саны',
+    'total_storage_used' => 'Жалпы қолданылған сақтау көлемі',
+    'newest_backup_date' => 'Соңғы резервтік көшірме күні',
+    'oldest_backup_date' => 'Ең ескі резервтік көшірме күні',
+];

--- a/lang/vendor/backup/ko/notifications.php
+++ b/lang/vendor/backup/ko/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => '예외 메시지: :message',
+    'exception_trace' => '예외 추적: :trace',
+    'exception_message_title' => '예외 메시지',
+    'exception_trace_title' => '예외 추적',
+
+    'backup_failed_subject' => ':application_name 백업 실패',
+    'backup_failed_body' => '중요: :application_name 백업 중 오류 발생',
+
+    'backup_successful_subject' => ':application_name 백업 성공',
+    'backup_successful_subject_title' => '백업이 성공적으로 완료되었습니다!',
+    'backup_successful_body' => '좋은 소식입니다. :disk_name 디스크에 :application_name 백업이 성공적으로 완료되었습니다.',
+
+    'cleanup_failed_subject' => ':application_name 백업 정리 실패',
+    'cleanup_failed_body' => ':application_name 백업 정리 중 오류 발생',
+
+    'cleanup_successful_subject' => ':application_name 백업 정리 성공',
+    'cleanup_successful_subject_title' => '백업 정리가 성공적으로 완료되었습니다!',
+    'cleanup_successful_body' => ':disk_name 디스크에 저장된 :application_name 백업 정리가 성공적으로 완료되었습니다.',
+
+    'healthy_backup_found_subject' => ':application_name 백업은 정상입니다.',
+    'healthy_backup_found_subject_title' => ':application_name 백업은 정상입니다.',
+    'healthy_backup_found_body' => ':application_name 백업은 정상입니다. 수고하셨습니다!',
+
+    'unhealthy_backup_found_subject' => '중요: :application_name 백업에 문제가 있습니다.',
+    'unhealthy_backup_found_subject_title' => '중요: :application_name 백업에 문제가 있습니다. :problem',
+    'unhealthy_backup_found_body' => ':disk_name 디스크에 :application_name 백업에 문제가 있습니다.',
+    'unhealthy_backup_found_not_reachable' => '백업 위치에 액세스할 수 없습니다. :error',
+    'unhealthy_backup_found_empty' => '이 애플리케이션에는 백업이 없습니다.',
+    'unhealthy_backup_found_old' => ':date에 저장된 최신 백업이 너무 오래되었습니다.',
+    'unhealthy_backup_found_unknown' => '죄송합니다. 예기치 않은 오류가 발생했습니다.',
+    'unhealthy_backup_found_full' => '백업이 디스크 공간을 다 차지하고 있습니다. 현재 사용량 :disk_usage는 허용 한도 :disk_limit을 초과합니다.',
+
+    'no_backups_info' => '아직 백업이 생성되지 않았습니다.',
+    'application_name' => '애플리케이션 이름',
+    'backup_name' => '백업 이름',
+    'disk' => '디스크',
+    'newest_backup_size' => '최신 백업 크기',
+    'number_of_backups' => '백업 수',
+    'total_storage_used' => '총 사용 스토리지',
+    'newest_backup_date' => '최신 백업 날짜',
+    'oldest_backup_date' => '가장 오래된 백업 날짜',
+];

--- a/lang/vendor/backup/nl/notifications.php
+++ b/lang/vendor/backup/nl/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Fout bericht: :message',
+    'exception_trace' => 'Fout trace: :trace',
+    'exception_message_title' => 'Fout bericht',
+    'exception_trace_title' => 'Fout trace',
+
+    'backup_failed_subject' => 'Back-up van :application_name mislukt',
+    'backup_failed_body' => 'Belangrijk: Er ging iets fout tijdens het maken van een back-up van :application_name',
+
+    'backup_successful_subject' => 'Succesvolle nieuwe back-up van :application_name',
+    'backup_successful_subject_title' => 'Succesvolle nieuwe back-up!',
+    'backup_successful_body' => 'Goed nieuws, een nieuwe back-up van :application_name was succesvol aangemaakt op de schijf genaamd :disk_name.',
+
+    'cleanup_failed_subject' => 'Het opschonen van de back-ups van :application_name is mislukt.',
+    'cleanup_failed_body' => 'Er ging iets fout tijdens het opschonen van de back-ups van :application_name',
+
+    'cleanup_successful_subject' => 'Opschonen van :application_name back-ups was succesvol.',
+    'cleanup_successful_subject_title' => 'Opschonen van back-ups was succesvol!',
+    'cleanup_successful_body' => 'Het opschonen van de :application_name back-ups op de schijf genaamd :disk_name was succesvol.',
+
+    'healthy_backup_found_subject' => 'De back-ups voor :application_name op schijf :disk_name zijn gezond',
+    'healthy_backup_found_subject_title' => 'De back-ups voor :application_name zijn gezond',
+    'healthy_backup_found_body' => 'De back-ups voor :application_name worden als gezond beschouwd. Goed gedaan!',
+
+    'unhealthy_backup_found_subject' => 'Belangrijk: De back-ups voor :application_name zijn niet meer gezond',
+    'unhealthy_backup_found_subject_title' => 'Belangrijk: De back-ups voor :application_name zijn niet gezond. :problem',
+    'unhealthy_backup_found_body' => 'De back-ups voor :application_name op schijf :disk_name zijn niet gezond.',
+    'unhealthy_backup_found_not_reachable' => 'De back-upbestemming kon niet worden bereikt. :error',
+    'unhealthy_backup_found_empty' => 'Er zijn geen back-ups van deze applicatie beschikbaar.',
+    'unhealthy_backup_found_old' => 'De laatste back-up gemaakt op :date is te oud.',
+    'unhealthy_backup_found_unknown' => 'Sorry, een exacte reden kon niet worden bepaald.',
+    'unhealthy_backup_found_full' => 'De back-ups gebruiken te veel opslagruimte. Momenteel wordt er :disk_usage gebruikt wat hoger is dan de toegestane limiet van :disk_limit.',
+
+    'no_backups_info' => 'Er zijn nog geen back-ups gemaakt',
+    'application_name' => 'Naam van de toepassing',
+    'backup_name' => 'Back-upnaam',
+    'disk' => 'Schijf',
+    'newest_backup_size' => 'Nieuwste back-upgrootte',
+    'number_of_backups' => 'Aantal back-ups',
+    'total_storage_used' => 'Totale gebruikte opslagruimte',
+    'newest_backup_date' => 'Datum nieuwste back-up',
+    'oldest_backup_date' => 'Datum oudste back-up',
+];

--- a/lang/vendor/backup/no/notifications.php
+++ b/lang/vendor/backup/no/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Exception: :message',
+    'exception_trace' => 'Exception trace: :trace',
+    'exception_message_title' => 'Exception',
+    'exception_trace_title' => 'Exception trace',
+
+    'backup_failed_subject' => 'Backup feilet for :application_name',
+    'backup_failed_body' => 'Viktg: En feil oppstod under backing av :application_name',
+
+    'backup_successful_subject' => 'Gjennomført backup av :application_name',
+    'backup_successful_subject_title' => 'Gjennomført backup!',
+    'backup_successful_body' => 'Gode nyheter, en ny backup av :application_name ble opprettet på disken :disk_name.',
+
+    'cleanup_failed_subject' => 'Opprydding av backup for :application_name feilet.',
+    'cleanup_failed_body' => 'En feil oppstod under opprydding av backups for :application_name',
+
+    'cleanup_successful_subject' => 'Opprydding av backup for :application_name gjennomført',
+    'cleanup_successful_subject_title' => 'Opprydding av backup gjennomført!',
+    'cleanup_successful_body' => 'Oppryddingen av backup for :application_name på disken :disk_name har blitt gjennomført.',
+
+    'healthy_backup_found_subject' => 'Alle backups for :application_name på disken :disk_name er OK',
+    'healthy_backup_found_subject_title' => 'Alle backups for :application_name er OK',
+    'healthy_backup_found_body' => 'Alle backups for :application_name er ok. Godt jobba!',
+
+    'unhealthy_backup_found_subject' => 'Viktig: Backups for :application_name ikke OK',
+    'unhealthy_backup_found_subject_title' => 'Viktig: Backups for :application_name er ikke OK. :problem',
+    'unhealthy_backup_found_body' => 'Backups for :application_name på disken :disk_name er ikke OK.',
+    'unhealthy_backup_found_not_reachable' => 'Kunne ikke finne backup-destinasjonen. :error',
+    'unhealthy_backup_found_empty' => 'Denne applikasjonen mangler backups.',
+    'unhealthy_backup_found_old' => 'Den siste backupem fra :date er for gammel.',
+    'unhealthy_backup_found_unknown' => 'Beklager, kunne ikke finne nøyaktig årsak.',
+    'unhealthy_backup_found_full' => 'Backups bruker for mye lagringsplass. Nåværende diskbruk er :disk_usage, som er mer enn den tillatte grensen på :disk_limit.',
+
+    'no_backups_info' => 'Ingen sikkerhetskopier ble gjort ennå',
+    'application_name' => 'Programnavn',
+    'backup_name' => 'Navn på sikkerhetskopi',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Nyeste backup-størrelse',
+    'number_of_backups' => 'Antall sikkerhetskopier',
+    'total_storage_used' => 'Total lagring brukt',
+    'newest_backup_date' => 'Nyeste backup-størrelse',
+    'oldest_backup_date' => 'Eldste sikkerhetskopistørrelse',
+];

--- a/lang/vendor/backup/pl/notifications.php
+++ b/lang/vendor/backup/pl/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Błąd: :message',
+    'exception_trace' => 'Zrzut błędu: :trace',
+    'exception_message_title' => 'Błąd',
+    'exception_trace_title' => 'Zrzut błędu',
+
+    'backup_failed_subject' => 'Tworzenie kopii zapasowej aplikacji :application_name nie powiodło się',
+    'backup_failed_body' => 'Ważne: Wystąpił błąd podczas tworzenia kopii zapasowej aplikacji :application_name',
+
+    'backup_successful_subject' => 'Pomyślnie utworzono kopię zapasową aplikacji :application_name',
+    'backup_successful_subject_title' => 'Nowa kopia zapasowa!',
+    'backup_successful_body' => 'Wspaniała wiadomość, nowa kopia zapasowa aplikacji :application_name została pomyślnie utworzona na dysku o nazwie :disk_name.',
+
+    'cleanup_failed_subject' => 'Czyszczenie kopii zapasowych aplikacji :application_name nie powiodło się.',
+    'cleanup_failed_body' => 'Wystąpił błąd podczas czyszczenia kopii zapasowej aplikacji :application_name',
+
+    'cleanup_successful_subject' => 'Kopie zapasowe aplikacji :application_name zostały pomyślnie wyczyszczone',
+    'cleanup_successful_subject_title' => 'Kopie zapasowe zostały pomyślnie wyczyszczone!',
+    'cleanup_successful_body' => 'Czyszczenie kopii zapasowych aplikacji :application_name na dysku :disk_name zakończone sukcesem.',
+
+    'healthy_backup_found_subject' => 'Kopie zapasowe aplikacji :application_name na dysku :disk_name są poprawne',
+    'healthy_backup_found_subject_title' => 'Kopie zapasowe aplikacji :application_name są poprawne',
+    'healthy_backup_found_body' => 'Kopie zapasowe aplikacji :application_name są poprawne. Dobra robota!',
+
+    'unhealthy_backup_found_subject' => 'Ważne: Kopie zapasowe aplikacji :application_name są niepoprawne',
+    'unhealthy_backup_found_subject_title' => 'Ważne: Kopie zapasowe aplikacji :application_name są niepoprawne. :problem',
+    'unhealthy_backup_found_body' => 'Kopie zapasowe aplikacji :application_name na dysku :disk_name są niepoprawne.',
+    'unhealthy_backup_found_not_reachable' => 'Miejsce docelowe kopii zapasowej nie jest osiągalne. :error',
+    'unhealthy_backup_found_empty' => 'W aplikacji nie ma żadnej kopii zapasowych tej aplikacji.',
+    'unhealthy_backup_found_old' => 'Ostatnia kopia zapasowa wykonania dnia :date jest zbyt stara.',
+    'unhealthy_backup_found_unknown' => 'Niestety, nie można ustalić dokładnego błędu.',
+    'unhealthy_backup_found_full' => 'Kopie zapasowe zajmują zbyt dużo miejsca. Obecne użycie dysku :disk_usage jest większe od ustalonego limitu :disk_limit.',
+
+    'no_backups_info' => 'Nie utworzono jeszcze kopii zapasowych',
+    'application_name' => 'Nazwa aplikacji',
+    'backup_name' => 'Nazwa kopii zapasowej',
+    'disk' => 'Dysk',
+    'newest_backup_size' => 'Najnowszy rozmiar kopii zapasowej',
+    'number_of_backups' => 'Liczba kopii zapasowych',
+    'total_storage_used' => 'Całkowite wykorzystane miejsce',
+    'newest_backup_date' => 'Najnowszy rozmiar kopii zapasowej',
+    'oldest_backup_date' => 'Najstarszy rozmiar kopii zapasowej',
+];

--- a/lang/vendor/backup/pt/notifications.php
+++ b/lang/vendor/backup/pt/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Mensagem de exceção: :message',
+    'exception_trace' => 'Rasto da exceção: :trace',
+    'exception_message_title' => 'Mensagem de exceção',
+    'exception_trace_title' => 'Rasto da exceção',
+
+    'backup_failed_subject' => 'Falha no backup da aplicação :application_name',
+    'backup_failed_body' => 'Importante: Ocorreu um erro ao executar o backup da aplicação :application_name',
+
+    'backup_successful_subject' => 'Backup realizado com sucesso: :application_name',
+    'backup_successful_subject_title' => 'Backup Realizado com Sucesso!',
+    'backup_successful_body' => 'Boas notícias, foi criado um novo backup no disco :disk_name referente à aplicação :application_name.',
+
+    'cleanup_failed_subject' => 'Falha na limpeza dos backups da aplicação :application_name.',
+    'cleanup_failed_body' => 'Ocorreu um erro ao executar a limpeza dos backups da aplicação :application_name',
+
+    'cleanup_successful_subject' => 'Limpeza dos backups da aplicação :application_name concluída!',
+    'cleanup_successful_subject_title' => 'Limpeza dos backups concluída!',
+    'cleanup_successful_body' => 'Concluída a limpeza dos backups da aplicação :application_name no disco :disk_name.',
+
+    'healthy_backup_found_subject' => 'Os backups da aplicação :application_name no disco :disk_name estão em dia',
+    'healthy_backup_found_subject_title' => 'Os backups da aplicação :application_name estão em dia',
+    'healthy_backup_found_body' => 'Os backups da aplicação :application_name estão em dia. Bom trabalho!',
+
+    'unhealthy_backup_found_subject' => 'Importante: Os backups da aplicação :application_name não estão em dia',
+    'unhealthy_backup_found_subject_title' => 'Importante: Os backups da aplicação :application_name não estão em dia. :problem',
+    'unhealthy_backup_found_body' => 'Os backups da aplicação :application_name no disco :disk_name não estão em dia.',
+    'unhealthy_backup_found_not_reachable' => 'O destino dos backups não pode ser alcançado. :error',
+    'unhealthy_backup_found_empty' => 'Não existem backups para essa aplicação.',
+    'unhealthy_backup_found_old' => 'O último backup realizado em :date é demasiado antigo.',
+    'unhealthy_backup_found_unknown' => 'Desculpe, impossível determinar a razão exata.',
+    'unhealthy_backup_found_full' => 'Os backups estão a utilizar demasiado espaço de armazenamento. A utilização atual é de :disk_usage, o que é maior que o limite permitido de :disk_limit.',
+
+    'no_backups_info' => 'Nenhum backup foi feito ainda',
+    'application_name' => 'Nome da Aplicação',
+    'backup_name' => 'Nome de backup',
+    'disk' => 'Disco',
+    'newest_backup_size' => 'Tamanho de backup mais recente',
+    'number_of_backups' => 'Número de backups',
+    'total_storage_used' => 'Armazenamento total usado',
+    'newest_backup_date' => 'Data de backup mais recente',
+    'oldest_backup_date' => 'Data de backup mais antiga',
+];

--- a/lang/vendor/backup/pt_BR/notifications.php
+++ b/lang/vendor/backup/pt_BR/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Mensagem de exceção: :message',
+    'exception_trace' => 'Rastreamento de exceção: :trace',
+    'exception_message_title' => 'Mensagem de exceção',
+    'exception_trace_title' => 'Rastreamento de exceção',
+
+    'backup_failed_subject' => 'Falha no backup da aplicação :application_name',
+    'backup_failed_body' => 'Importante: Ocorreu um erro ao fazer o backup da aplicação :application_name',
+
+    'backup_successful_subject' => 'Backup realizado com sucesso: :application_name',
+    'backup_successful_subject_title' => 'Backup Realizado com sucesso!',
+    'backup_successful_body' => 'Boas notícias, um novo backup da aplicação :application_name foi criado no disco :disk_name.',
+
+    'cleanup_failed_subject' => 'Falha na limpeza dos backups da aplicação :application_name.',
+    'cleanup_failed_body' => 'Um erro ocorreu ao fazer a limpeza dos backups da aplicação :application_name',
+
+    'cleanup_successful_subject' => 'Limpeza dos backups da aplicação :application_name concluída!',
+    'cleanup_successful_subject_title' => 'Limpeza dos backups concluída!',
+    'cleanup_successful_body' => 'A limpeza dos backups da aplicação :application_name no disco :disk_name foi concluída.',
+
+    'healthy_backup_found_subject' => 'Os backups da aplicação :application_name no disco :disk_name estão em dia',
+    'healthy_backup_found_subject_title' => 'Os backups da aplicação :application_name estão em dia',
+    'healthy_backup_found_body' => 'Os backups da aplicação :application_name estão em dia. Bom trabalho!',
+
+    'unhealthy_backup_found_subject' => 'Importante: Os backups da aplicação :application_name não estão em dia',
+    'unhealthy_backup_found_subject_title' => 'Importante: Os backups da aplicação :application_name não estão em dia. :problem',
+    'unhealthy_backup_found_body' => 'Os backups da aplicação :application_name no disco :disk_name não estão em dia.',
+    'unhealthy_backup_found_not_reachable' => 'O destino dos backups não pode ser alcançado. :error',
+    'unhealthy_backup_found_empty' => 'Não existem backups para essa aplicação.',
+    'unhealthy_backup_found_old' => 'O último backup realizado em :date é considerado muito antigo.',
+    'unhealthy_backup_found_unknown' => 'Desculpe, a exata razão não pode ser encontrada.',
+    'unhealthy_backup_found_full' => 'Os backups estão usando muito espaço de armazenamento. A utilização atual é de :disk_usage, o que é maior que o limite permitido de :disk_limit.',
+
+    'no_backups_info' => 'Nenhum backup foi feito ainda',
+    'application_name' => 'Nome da Aplicação',
+    'backup_name' => 'Nome de backup',
+    'disk' => 'Disco',
+    'newest_backup_size' => 'Tamanho do backup mais recente',
+    'number_of_backups' => 'Número de backups',
+    'total_storage_used' => 'Armazenamento total usado',
+    'newest_backup_date' => 'Data do backup mais recente',
+    'oldest_backup_date' => 'Data do backup mais antigo',
+];

--- a/lang/vendor/backup/ro/notifications.php
+++ b/lang/vendor/backup/ro/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Cu excepția mesajului: :message',
+    'exception_trace' => 'Urmă excepţie: :trace',
+    'exception_message_title' => 'Mesaj de excepție',
+    'exception_trace_title' => 'Urmă excepţie',
+
+    'backup_failed_subject' => 'Nu s-a putut face copie de rezervă pentru :application_name',
+    'backup_failed_body' => 'Important: A apărut o eroare în timpul generării copiei de rezervă pentru :application_name',
+
+    'backup_successful_subject' => 'Copie de rezervă efectuată cu succes pentru :application_name',
+    'backup_successful_subject_title' => 'O nouă copie de rezervă a fost efectuată cu succes!',
+    'backup_successful_body' => 'Vești bune, o nouă copie de rezervă pentru :application_name a fost creată cu succes pe discul cu numele :disk_name.',
+
+    'cleanup_failed_subject' => 'Curățarea copiilor de rezervă pentru :application_name nu a reușit.',
+    'cleanup_failed_body' => 'A apărut o eroare în timpul curățirii copiilor de rezervă pentru :application_name',
+
+    'cleanup_successful_subject' => 'Curățarea copiilor de rezervă pentru :application_name a fost făcută cu succes',
+    'cleanup_successful_subject_title' => 'Curățarea copiilor de rezervă a fost făcută cu succes!',
+    'cleanup_successful_body' => 'Curățarea copiilor de rezervă pentru :application_name de pe discul cu numele :disk_name a fost făcută cu succes.',
+
+    'healthy_backup_found_subject' => 'Copiile de rezervă pentru :application_name de pe discul :disk_name sunt în regulă',
+    'healthy_backup_found_subject_title' => 'Copiile de rezervă pentru :application_name sunt în regulă',
+    'healthy_backup_found_body' => 'Copiile de rezervă pentru :application_name sunt considerate în regulă. Bună treabă!',
+
+    'unhealthy_backup_found_subject' => 'Important: Copiile de rezervă pentru :application_name nu sunt în regulă',
+    'unhealthy_backup_found_subject_title' => 'Important: Copiile de rezervă pentru :application_name nu sunt în regulă. :problem',
+    'unhealthy_backup_found_body' => 'Copiile de rezervă pentru :application_name de pe discul :disk_name nu sunt în regulă.',
+    'unhealthy_backup_found_not_reachable' => 'Nu se poate ajunge la destinația copiilor de rezervă. :error',
+    'unhealthy_backup_found_empty' => 'Nu există copii de rezervă ale acestei aplicații.',
+    'unhealthy_backup_found_old' => 'Cea mai recentă copie de rezervă făcută la :date este considerată prea veche.',
+    'unhealthy_backup_found_unknown' => 'Ne pare rău, un motiv exact nu poate fi determinat.',
+    'unhealthy_backup_found_full' => 'Copiile de rezervă folosesc prea mult spațiu de stocare. Utilizarea curentă este de :disk_usage care este mai mare decât limita permisă de :disk_limit.',
+
+    'no_backups_info' => 'Nu s-au făcut încă copii de rezervă',
+    'application_name' => 'Numele aplicatiei',
+    'backup_name' => 'Numele de rezervă',
+    'disk' => 'Disc',
+    'newest_backup_size' => 'Cea mai nouă dimensiune de rezervă',
+    'number_of_backups' => 'Număr de copii de rezervă',
+    'total_storage_used' => 'Spațiu total de stocare utilizat',
+    'newest_backup_date' => 'Cea mai nouă dimensiune de rezervă',
+    'oldest_backup_date' => 'Cea mai veche dimensiune de rezervă',
+];

--- a/lang/vendor/backup/ru/notifications.php
+++ b/lang/vendor/backup/ru/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Сообщение об ошибке: :message',
+    'exception_trace' => 'Сведения об ошибке: :trace',
+    'exception_message_title' => 'Сообщение об ошибке',
+    'exception_trace_title' => 'Сведения об ошибке',
+
+    'backup_failed_subject' => 'Не удалось сделать резервную копию :application_name',
+    'backup_failed_body' => 'Внимание: Произошла ошибка во время резервного копирования :application_name',
+
+    'backup_successful_subject' => 'Успешно создана новая резервная копия :application_name',
+    'backup_successful_subject_title' => 'Успешно создана новая резервная копия!',
+    'backup_successful_body' => 'Отличная новость, новая резервная копия :application_name успешно создана и сохранена на диск :disk_name.',
+
+    'cleanup_failed_subject' => 'Не удалось очистить резервные копии :application_name',
+    'cleanup_failed_body' => 'Произошла ошибка при очистке резервных копий :application_name',
+
+    'cleanup_successful_subject' => 'Очистка от резервных копий :application_name прошла успешно',
+    'cleanup_successful_subject_title' => 'Очистка резервных копий прошла успешно!',
+    'cleanup_successful_body' => 'Очистка от старых резервных копий :application_name на диске :disk_name прошла успешно.',
+
+    'healthy_backup_found_subject' => 'Резервные копии :application_name с диска :disk_name исправны',
+    'healthy_backup_found_subject_title' => 'Резервные копии :application_name исправны',
+    'healthy_backup_found_body' => 'Резервные копии :application_name считаются исправными. Хорошая работа!',
+
+    'unhealthy_backup_found_subject' => 'Внимание: резервные копии :application_name неисправны',
+    'unhealthy_backup_found_subject_title' => 'Внимание: резервные копии для :application_name неисправны. :problem',
+    'unhealthy_backup_found_body' => 'Резервные копии для :application_name на диске :disk_name неисправны.',
+    'unhealthy_backup_found_not_reachable' => 'Не удается достичь места назначения резервной копии. :error',
+    'unhealthy_backup_found_empty' => 'Резервные копии для этого приложения отсутствуют.',
+    'unhealthy_backup_found_old' => 'Последнее резервное копирование созданное :date является устаревшим.',
+    'unhealthy_backup_found_unknown' => 'Извините, точная причина не может быть определена.',
+    'unhealthy_backup_found_full' => 'Резервные копии используют слишком много памяти. Используется :disk_usage что выше допустимого предела: :disk_limit.',
+
+    'no_backups_info' => 'Резервных копий еще не было',
+    'application_name' => 'Имя приложения',
+    'backup_name' => 'Имя резервной копии',
+    'disk' => 'Диск',
+    'newest_backup_size' => 'Размер последней резервной копии',
+    'number_of_backups' => 'Количество резервных копий',
+    'total_storage_used' => 'Общий объем используемого хранилища',
+    'newest_backup_date' => 'Дата последней резервной копии',
+    'oldest_backup_date' => 'Дата самой старой резервной копии',
+];

--- a/lang/vendor/backup/sk/notifications.php
+++ b/lang/vendor/backup/sk/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Správa výnimky: :message',
+    'exception_trace' => 'Stopa výnimky: :trace',
+    'exception_message_title' => 'Správa výnimky',
+    'exception_trace_title' => 'Stopa výnimky',
+
+    'backup_failed_subject' => 'Záloha :application_name zlyhala',
+    'backup_failed_body' => 'Dôležité: Pri zálohovaní :application_name sa vyskytla chyba',
+
+    'backup_successful_subject' => 'Úspešná nová záloha :application_name',
+    'backup_successful_subject_title' => 'Úspešná nová záloha!',
+    'backup_successful_body' => 'Dobrá správa, na disku s názvom :disk_name bola úspešne vytvorená nová záloha :application_name.',
+
+    'cleanup_failed_subject' => 'Vyčistenie záloh :application_name zlyhalo.',
+    'cleanup_failed_body' => 'Pri čistení záloh :application_name sa vyskytla chyba',
+
+    'cleanup_successful_subject' => 'Vyčistenie záloh :application_name bolo úspešné',
+    'cleanup_successful_subject_title' => 'Vyčistenie záloh bolo úspešné!',
+    'cleanup_successful_body' => 'Vyčistenie záloh :application_name na disku s názvom :disk_name bolo úspešné.',
+
+    'healthy_backup_found_subject' => 'Zálohy pre :application_name na disku :disk_name sú zdravé',
+    'healthy_backup_found_subject_title' => 'Zálohy pre :application_name sú zdravé',
+    'healthy_backup_found_body' => 'Zálohy pre :application_name sa považujú za zdravé. Dobrá práca!',
+
+    'unhealthy_backup_found_subject' => 'Dôležité: Zálohy pre :application_name sú nezdravé',
+    'unhealthy_backup_found_subject_title' => 'Dôležité: Zálohy pre :application_name sú nezdravé. :problem',
+    'unhealthy_backup_found_body' => 'Zálohy pre :application_name na disku :disk_name sú nezdravé.',
+    'unhealthy_backup_found_not_reachable' => 'Nemožno sa dostať k cieľu zálohy. :error',
+    'unhealthy_backup_found_empty' => 'Táto aplikácia nemá žiadne zálohy.',
+    'unhealthy_backup_found_old' => 'Posledná záloha vytvorená dňa :date sa považuje za príliš starú.',
+    'unhealthy_backup_found_unknown' => 'Ospravedlňujeme sa, nemôžeme určiť presný dôvod.',
+    'unhealthy_backup_found_full' => 'Zálohy zaberajú príliš veľa miesta na disku. Aktuálne využitie disku je :disk_usage, čo je viac ako povolený limit :disk_limit.',
+
+    'no_backups_info' => 'Zatiaľ neboli vytvorené žiadne zálohy',
+    'application_name' => 'Názov aplikácie',
+    'backup_name' => 'Názov zálohy',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'Veľkosť najnovšej zálohy',
+    'number_of_backups' => 'Počet záloh',
+    'total_storage_used' => 'Celková využitá kapacita úložiska',
+    'newest_backup_date' => 'Dátum najnovšej zálohy',
+    'oldest_backup_date' => 'Dátum najstaršej zálohy',
+];

--- a/lang/vendor/backup/tr/notifications.php
+++ b/lang/vendor/backup/tr/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Hata mesajı: :message',
+    'exception_trace' => 'Hata izleri: :trace',
+    'exception_message_title' => 'Hata mesajı',
+    'exception_trace_title' => 'Hata izleri',
+
+    'backup_failed_subject' => 'Yedeklenemedi :application_name',
+    'backup_failed_body' => 'Önemli: Yedeklenirken bir hata oluştu :application_name',
+
+    'backup_successful_subject' => 'Başarılı :application_name yeni yedeklemesi',
+    'backup_successful_subject_title' => 'Başarılı bir yeni yedekleme!',
+    'backup_successful_body' => 'Harika bir haber, :application_name ait yeni bir yedekleme :disk_name adlı diskte başarıyla oluşturuldu.',
+
+    'cleanup_failed_subject' => ':application_name yedeklemeleri temizlenmesi başarısız.',
+    'cleanup_failed_body' => ':application_name yedeklerini temizlerken bir hata oluştu ',
+
+    'cleanup_successful_subject' => ':application_name yedeklemeleri temizlenmesi başarılı.',
+    'cleanup_successful_subject_title' => 'Yedeklerin temizlenmesi başarılı!',
+    'cleanup_successful_body' => ':application_name yedeklemeleri temizlenmesi, :disk_name diskinden silindi',
+
+    'healthy_backup_found_subject' => ':application_name yedeklenmesi, :disk_name adlı diskte sağlıklı',
+    'healthy_backup_found_subject_title' => ':application_name yedeklenmesi sağlıklı',
+    'healthy_backup_found_body' => ':application_name için yapılan yedeklemeler sağlıklı sayılır. Aferin!',
+
+    'unhealthy_backup_found_subject' => 'Önemli: :application_name için yedeklemeler sağlıksız',
+    'unhealthy_backup_found_subject_title' => 'Önemli: :application_name için yedeklemeler sağlıksız. :problem',
+    'unhealthy_backup_found_body' => 'Yedeklemeler: :application_name disk: :disk_name sağlıksız.',
+    'unhealthy_backup_found_not_reachable' => 'Yedekleme hedefine ulaşılamıyor. :error',
+    'unhealthy_backup_found_empty' => 'Bu uygulamanın yedekleri yok.',
+    'unhealthy_backup_found_old' => ':date tarihinde yapılan en son yedekleme çok eski kabul ediliyor.',
+    'unhealthy_backup_found_unknown' => 'Üzgünüm, kesin bir sebep belirlenemiyor.',
+    'unhealthy_backup_found_full' => 'Yedeklemeler çok fazla depolama alanı kullanıyor. Şu anki kullanım: :disk_usage, izin verilen sınırdan yüksek: :disk_limit.',
+
+    'no_backups_info' => 'Henüz yedekleme yapılmadı',
+    'application_name' => 'Uygulama Adı',
+    'backup_name' => 'Yedek adı',
+    'disk' => 'Disk',
+    'newest_backup_size' => 'En yeni yedekleme boyutu',
+    'number_of_backups' => 'Yedekleme sayısı',
+    'total_storage_used' => 'Kullanılan toplam depolama alanı',
+    'newest_backup_date' => 'En yeni yedekleme tarihi',
+    'oldest_backup_date' => 'En eski yedekleme tarihi',
+];

--- a/lang/vendor/backup/uk/notifications.php
+++ b/lang/vendor/backup/uk/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => 'Повідомлення про помилку: :message',
+    'exception_trace' => 'Деталі помилки: :trace',
+    'exception_message_title' => 'Повідомлення помилки',
+    'exception_trace_title' => 'Деталі помилки',
+
+    'backup_failed_subject' => 'Не вдалось зробити резервну копію :application_name',
+    'backup_failed_body' => 'Увага: Трапилась помилка під час резервного копіювання :application_name',
+
+    'backup_successful_subject' => 'Успішне резервне копіювання :application_name',
+    'backup_successful_subject_title' => 'Успішно створена резервна копія!',
+    'backup_successful_body' => 'Чудова новина, нова резервна копія :application_name успішно створена і збережена на диск :disk_name.',
+
+    'cleanup_failed_subject' => 'Не вдалось очистити резервні копії :application_name',
+    'cleanup_failed_body' => 'Сталася помилка під час очищення резервних копій :application_name',
+
+    'cleanup_successful_subject' => 'Успішне очищення від резервних копій :application_name',
+    'cleanup_successful_subject_title' => 'Очищення резервних копій пройшло вдало!',
+    'cleanup_successful_body' => 'Очищенно від старих резервних копій :application_name на диску :disk_name пойшло успішно.',
+
+    'healthy_backup_found_subject' => 'Резервна копія :application_name з диску :disk_name установлена',
+    'healthy_backup_found_subject_title' => 'Резервна копія :application_name установлена',
+    'healthy_backup_found_body' => 'Резервна копія :application_name успішно установлена. Хороша робота!',
+
+    'unhealthy_backup_found_subject' => 'Увага: резервна копія :application_name не установилась',
+    'unhealthy_backup_found_subject_title' => 'Увага: резервна копія для :application_name не установилась. :problem',
+    'unhealthy_backup_found_body' => 'Резервна копія для :application_name на диску :disk_name не установилась.',
+    'unhealthy_backup_found_not_reachable' => 'Резервна копія не змогла установитись. :error',
+    'unhealthy_backup_found_empty' => 'Резервні копії для цього додатку відсутні.',
+    'unhealthy_backup_found_old' => 'Останнє резервне копіювання створено :date є застарілим.',
+    'unhealthy_backup_found_unknown' => 'Вибачте, але ми не змогли визначити точну причину.',
+    'unhealthy_backup_found_full' => 'Резервні копії використовують занадто багато пам`яті. Використовується :disk_usage що вище за допустиму межу :disk_limit.',
+
+    'no_backups_info' => 'Резервних копій ще не було зроблено',
+    'application_name' => 'Назва програми',
+    'backup_name' => 'Резервне ім’я',
+    'disk' => 'Диск',
+    'newest_backup_size' => 'Найновіший розмір резервної копії',
+    'number_of_backups' => 'Кількість резервних копій',
+    'total_storage_used' => 'Загальний обсяг використаного сховища',
+    'newest_backup_date' => 'Найновіший розмір резервної копії',
+    'oldest_backup_date' => 'Найстаріший розмір резервної копії',
+];

--- a/lang/vendor/backup/zh_CN/notifications.php
+++ b/lang/vendor/backup/zh_CN/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => '异常信息: :message',
+    'exception_trace' => '异常跟踪: :trace',
+    'exception_message_title' => '异常信息',
+    'exception_trace_title' => '异常跟踪',
+
+    'backup_failed_subject' => ':application_name 备份失败',
+    'backup_failed_body' => '重要说明：备份 :application_name 时发生错误',
+
+    'backup_successful_subject' => ':application_name 备份成功',
+    'backup_successful_subject_title' => '备份成功！',
+    'backup_successful_body' => '好消息, :application_name 备份成功，位于磁盘 :disk_name 中。',
+
+    'cleanup_failed_subject' => '清除 :application_name 的备份失败。',
+    'cleanup_failed_body' => '清除备份 :application_name 时发生错误',
+
+    'cleanup_successful_subject' => '成功清除 :application_name 的备份',
+    'cleanup_successful_subject_title' => '成功清除备份！',
+    'cleanup_successful_body' => '成功清除 :disk_name 磁盘上 :application_name 的备份。',
+
+    'healthy_backup_found_subject' => ':disk_name 磁盘上 :application_name 的备份是健康的',
+    'healthy_backup_found_subject_title' => ':application_name 的备份是健康的',
+    'healthy_backup_found_body' => ':application_name 的备份是健康的。干的好！',
+
+    'unhealthy_backup_found_subject' => '重要说明：:application_name 的备份不健康',
+    'unhealthy_backup_found_subject_title' => '重要说明：:application_name 备份不健康。 :problem',
+    'unhealthy_backup_found_body' => ':disk_name 磁盘上 :application_name 的备份不健康。',
+    'unhealthy_backup_found_not_reachable' => '无法访问备份目标。 :error',
+    'unhealthy_backup_found_empty' => '根本没有此应用程序的备份。',
+    'unhealthy_backup_found_old' => '最近的备份创建于 :date ，太旧了。',
+    'unhealthy_backup_found_unknown' => '对不起，确切原因无法确定。',
+    'unhealthy_backup_found_full' => '备份占用了太多存储空间。当前占用了 :disk_usage ，高于允许的限制 :disk_limit。',
+
+    'no_backups_info' => '尚未进行任何备份',
+    'application_name' => '应用名称',
+    'backup_name' => '备份名称',
+    'disk' => '磁盘',
+    'newest_backup_size' => '最新备份大小',
+    'number_of_backups' => '备份数量',
+    'total_storage_used' => '使用的总存储量',
+    'newest_backup_date' => '最新备份大小',
+    'oldest_backup_date' => '最旧的备份大小',
+];

--- a/lang/vendor/backup/zh_TW/notifications.php
+++ b/lang/vendor/backup/zh_TW/notifications.php
@@ -1,0 +1,45 @@
+<?php
+
+return [
+    'exception_message' => '異常訊息: :message',
+    'exception_trace' => '異常追蹤: :trace',
+    'exception_message_title' => '異常訊息',
+    'exception_trace_title' => '異常追蹤',
+
+    'backup_failed_subject' => ':application_name 備份失敗',
+    'backup_failed_body' => '重要說明：備份 :application_name 時發生錯誤',
+
+    'backup_successful_subject' => ':application_name 備份成功',
+    'backup_successful_subject_title' => '備份成功！',
+    'backup_successful_body' => '好消息, :application_name 備份成功，位於磁碟 :disk_name 中。',
+
+    'cleanup_failed_subject' => '清除 :application_name 的備份失敗。',
+    'cleanup_failed_body' => '清除備份 :application_name 時發生錯誤',
+
+    'cleanup_successful_subject' => '成功清除 :application_name 的備份',
+    'cleanup_successful_subject_title' => '成功清除備份！',
+    'cleanup_successful_body' => '成功清除 :disk_name 磁碟上 :application_name 的備份。',
+
+    'healthy_backup_found_subject' => ':disk_name 磁碟上 :application_name 的備份是健康的',
+    'healthy_backup_found_subject_title' => ':application_name 的備份是健康的',
+    'healthy_backup_found_body' => ':application_name 的備份是健康的。幹的好！',
+
+    'unhealthy_backup_found_subject' => '重要說明：:application_name 的備份不健康',
+    'unhealthy_backup_found_subject_title' => '重要說明：:application_name 備份不健康。 :problem',
+    'unhealthy_backup_found_body' => ':disk_name 磁碟上 :application_name 的備份不健康。',
+    'unhealthy_backup_found_not_reachable' => '無法訪問備份目標。 :error',
+    'unhealthy_backup_found_empty' => '根本沒有此應用程序的備份。',
+    'unhealthy_backup_found_old' => '最近的備份創建於 :date ，太舊了。',
+    'unhealthy_backup_found_unknown' => '對不起，確切原因無法確定。',
+    'unhealthy_backup_found_full' => '備份佔用了太多存儲空間。當前佔用了 :disk_usage ，高於允許的限制 :disk_limit。',
+
+    'no_backups_info' => '尚未進行任何備份',
+    'application_name' => '應用名稱',
+    'backup_name' => '備份名稱',
+    'disk' => '磁碟',
+    'newest_backup_size' => '最新備份大小',
+    'number_of_backups' => '備份數量',
+    'total_storage_used' => '使用的總存儲量',
+    'newest_backup_date' => '最新備份大小',
+    'oldest_backup_date' => '最早的備份大小',
+];

--- a/resources/views/backup/index.blade.php
+++ b/resources/views/backup/index.blade.php
@@ -280,6 +280,7 @@
                         });
                     }
                 });
+            });
 
             $('#uploadForm').submit(function(e) {
                 e.preventDefault();

--- a/resources/views/backup/index.blade.php
+++ b/resources/views/backup/index.blade.php
@@ -1,0 +1,355 @@
+@extends('layouts.index')
+
+@section('title', 'Backup Database')
+
+@section('content_header')
+    <h1>Backup Database</h1>
+@stop
+
+@section('content')
+    @include('partials.breadcrumbs')
+    @include('common.alerts')
+
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col-lg-12">
+                <div class="card card-outline card-primary">
+                    <div class="card-header">
+                        <h3 class="card-title">Kelola Backup Database</h3>
+                        <div class="card-tools">
+                            @if ($canwrite)
+                                <button type="button" id="btnBackup" class="btn btn-primary btn-sm">
+                                    <i class="fas fa-database mr-1"></i> Backup Sekarang
+                                </button>
+                                <button type="button" class="btn btn-success btn-sm" data-toggle="modal" data-target="#uploadModal">
+                                    <i class="fas fa-upload mr-1"></i> Upload & Restore
+                                </button>
+                            @endif
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <div class="table-responsive">
+                            <table class="table table-bordered table-striped" id="backupTable">
+                                <thead>
+                                    <tr>
+                                        <th>No</th>
+                                        <th>Nama File</th>
+                                        <th>Ukuran</th>
+                                        <th>Tanggal</th>
+                                        <th>Aksi</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @forelse ($backups as $i => $backup)
+                                        <tr>
+                                            <td>{{ $i + 1 }}</td>
+                                            <td>{{ $backup['filename'] }}</td>
+                                            <td>{{ number_format($backup['size'] / 1024, 2) }} KB</td>
+                                            <td>{{ \Carbon\Carbon::createFromTimestamp($backup['last_modified'])->isoFormat('DD-MM-Y HH:mm') }}</td>
+                                            <td>
+                                                <div class="btn-group">
+                                                    <a href="{{ route('backup.show', $backup['filename']) }}"
+                                                       class="btn btn-info btn-sm"
+                                                       title="Download">
+                                                        <i class="fas fa-download"></i>
+                                                    </a>
+                                                    @if ($canedit)
+                                                        <button type="button"
+                                                                class="btn btn-warning btn-sm btn-restore"
+                                                                data-filename="{{ $backup['filename'] }}"
+                                                                title="Restore">
+                                                            <i class="fas fa-undo"></i>
+                                                        </button>
+                                                    @endif
+                                                    @if ($candelete)
+                                                        <button type="button"
+                                                                class="btn btn-danger btn-sm btn-delete"
+                                                                data-filename="{{ $backup['filename'] }}"
+                                                                title="Hapus">
+                                                            <i class="fas fa-trash"></i>
+                                                        </button>
+                                                    @endif
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    @empty
+                                        <tr>
+                                            <td colspan="5" class="text-center">Belum ada backup.</td>
+                                        </tr>
+                                    @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="uploadModal" tabindex="-1" role="dialog">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Upload & Restore Backup</h5>
+                    <button type="button" class="close" data-dismiss="modal">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <form id="uploadForm" enctype="multipart/form-data">
+                    <div class="modal-body">
+                        <div class="alert alert-warning">
+                            <i class="fas fa-exclamation-triangle mr-2"></i>
+                            <strong>Perhatian!</strong>
+                            <p class="mb-0 mt-2">Semua data saat ini akan diganti dengan data dari file backup yang diupload. Tindakan ini tidak dapat dibatalkan.</p>
+                        </div>
+                        <div class="form-group">
+                            <label for="file">Pilih File Backup (.zip)</label>
+                            <div class="custom-file">
+                                <input type="file" class="custom-file-input" id="file" name="file" accept=".zip" required>
+                                <label class="custom-file-label" for="file">Pilih file...</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Batal</button>
+                        <button type="submit" class="btn btn-warning" id="btnUploadRestore">
+                            <i class="fas fa-undo mr-1"></i> Upload & Restore
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@stop
+
+@section('js')
+    <script nonce="{{ csp_nonce() }}">
+        document.addEventListener("DOMContentLoaded", function() {
+            $('#btnBackup').click(function() {
+                const btn = $(this);
+                const originalText = btn.html();
+
+                Swal.fire({
+                    title: 'Buat Backup?',
+                    text: 'Proses backup database akan berjalan. Lanjutkan?',
+                    icon: 'question',
+                    showCancelButton: true,
+                    confirmButtonText: '<i class="fas fa-play mr-2"></i>Ya, Backup',
+                    cancelButtonText: '<i class="fas fa-times mr-2"></i>Batal',
+                    reverseButtons: true
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        btn.prop('disabled', true)
+                           .html('<i class="fas fa-spinner fa-spin mr-2"></i>Memproses...');
+
+                        $.ajax({
+                            url: '{{ route('backup.store') }}',
+                            type: 'POST',
+                            data: { _token: '{{ csrf_token() }}' },
+                            success: function(response) {
+                                Swal.fire({
+                                    title: 'Berhasil!',
+                                    text: response.message,
+                                    icon: 'success',
+                                    confirmButtonText: 'OK'
+                                }).then(() => {
+                                    window.location.reload();
+                                });
+                            },
+                            error: function(xhr) {
+                                const resp = xhr.responseJSON;
+                                Swal.fire({
+                                    title: 'Gagal!',
+                                    text: resp?.message || 'Terjadi kesalahan',
+                                    icon: 'error',
+                                    confirmButtonText: 'OK'
+                                });
+                            },
+                            complete: function() {
+                                btn.prop('disabled', false).html(originalText);
+                            }
+                        });
+                    }
+                });
+            });
+
+            $('.btn-restore').click(function() {
+                const filename = $(this).data('filename');
+                const btn = $(this);
+                const originalText = btn.html();
+
+                Swal.fire({
+                    title: 'Restore Database?',
+                    html: `
+                        <div class="text-left">
+                            <div class="alert alert-warning">
+                                <i class="fas fa-exclamation-triangle mr-2"></i>
+                                <strong>Perhatian!</strong>
+                                <p class="mb-0 mt-2">Semua data saat ini akan diganti dengan data dari backup <strong>${filename}</strong>. Tindakan ini tidak dapat dibatalkan.</p>
+                            </div>
+                        </div>
+                    `,
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonColor: '#dc3545',
+                    cancelButtonColor: '#6c757d',
+                    confirmButtonText: '<i class="fas fa-undo mr-2"></i>Ya, Restore',
+                    cancelButtonText: '<i class="fas fa-times mr-2"></i>Batal',
+                    reverseButtons: true
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        btn.prop('disabled', true)
+                           .html('<i class="fas fa-spinner fa-spin mr-2"></i>Merestore...');
+
+                        $.ajax({
+                            url: '{{ route('backup.update', ['filename' => '__FILE__']) }}'.replace('__FILE__', filename),
+                            type: 'POST',
+                            data: { _token: '{{ csrf_token() }}' },
+                            success: function(response) {
+                                Swal.fire({
+                                    title: 'Berhasil!',
+                                    text: response.message,
+                                    icon: 'success',
+                                    confirmButtonText: 'OK'
+                                }).then(() => {
+                                    window.location.reload();
+                                });
+                            },
+                            error: function(xhr) {
+                                const resp = xhr.responseJSON;
+                                Swal.fire({
+                                    title: 'Gagal!',
+                                    text: resp?.message || 'Terjadi kesalahan',
+                                    icon: 'error',
+                                    confirmButtonText: 'OK'
+                                });
+                            },
+                            complete: function() {
+                                btn.prop('disabled', false).html(originalText);
+                            }
+                        });
+                    }
+                });
+            });
+
+            $('.btn-delete').click(function() {
+                const filename = $(this).data('filename');
+                const btn = $(this);
+                const originalText = btn.html();
+
+                Swal.fire({
+                    title: 'Hapus Backup?',
+                    text: `File ${filename} akan dihapus permanen.`,
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonColor: '#dc3545',
+                    cancelButtonColor: '#6c757d',
+                    confirmButtonText: '<i class="fas fa-trash mr-2"></i>Ya, Hapus',
+                    cancelButtonText: '<i class="fas fa-times mr-2"></i>Batal',
+                    reverseButtons: true
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        btn.prop('disabled', true);
+
+                        $.ajax({
+                            url: '{{ route('backup.destroy', ['filename' => '__FILE__']) }}'.replace('__FILE__', filename),
+                            type: 'DELETE',
+                            data: { _token: '{{ csrf_token() }}' },
+                            success: function(response) {
+                                Swal.fire({
+                                    title: 'Berhasil!',
+                                    text: response.message,
+                                    icon: 'success',
+                                    confirmButtonText: 'OK'
+                                }).then(() => {
+                                    window.location.reload();
+                                });
+                            },
+                            error: function(xhr) {
+                                const resp = xhr.responseJSON;
+                                Swal.fire({
+                                    title: 'Gagal!',
+                                    text: resp?.message || 'Terjadi kesalahan',
+                                    icon: 'error',
+                                    confirmButtonText: 'OK'
+                                });
+                            },
+                            complete: function() {
+                                btn.prop('disabled', false).html(originalText);
+                            }
+                        });
+                    }
+                });
+
+            $('#uploadForm').submit(function(e) {
+                e.preventDefault();
+                const formData = new FormData(this);
+                const btn = $('#btnUploadRestore');
+                const originalText = btn.html();
+
+                Swal.fire({
+                    title: 'Restore dari Upload?',
+                    html: `
+                        <div class="text-left">
+                            <div class="alert alert-warning">
+                                <i class="fas fa-exclamation-triangle mr-2"></i>
+                                <strong>Perhatian!</strong>
+                                <p class="mb-0 mt-2">Semua data akan diganti dengan data dari file yang diupload. Tindakan ini tidak dapat dibatalkan.</p>
+                            </div>
+                        </div>
+                    `,
+                    icon: 'warning',
+                    showCancelButton: true,
+                    confirmButtonColor: '#dc3545',
+                    cancelButtonColor: '#6c757d',
+                    confirmButtonText: '<i class="fas fa-undo mr-2"></i>Ya, Restore',
+                    cancelButtonText: '<i class="fas fa-times mr-2"></i>Batal',
+                    reverseButtons: true
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        btn.prop('disabled', true)
+                           .html('<i class="fas fa-spinner fa-spin mr-2"></i>Merestore...');
+
+                        $.ajax({
+                            url: '{{ route('backup.upload') }}',
+                            type: 'POST',
+                            data: formData,
+                            processData: false,
+                            contentType: false,
+                            success: function(response) {
+                                $('#uploadModal').modal('hide');
+                                $('#uploadForm')[0].reset();
+                                $('.custom-file-label').text('Pilih file...');
+                                Swal.fire({
+                                    title: 'Berhasil!',
+                                    text: response.message,
+                                    icon: 'success',
+                                    confirmButtonText: 'OK'
+                                }).then(() => {
+                                    window.location.reload();
+                                });
+                            },
+                            error: function(xhr) {
+                                const resp = xhr.responseJSON;
+                                Swal.fire({
+                                    title: 'Gagal!',
+                                    text: resp?.message || 'Terjadi kesalahan',
+                                    icon: 'error',
+                                    confirmButtonText: 'OK'
+                                });
+                            },
+                            complete: function() {
+                                btn.prop('disabled', false).html(originalText);
+                            }
+                        });
+                    }
+                });
+            });
+
+            $('.custom-file-input').change(function() {
+                const fileName = $(this).val().split('\\').pop();
+                $(this).next('.custom-file-label').text(fileName);
+            });
+        });
+    </script>
+@stop

--- a/routes/breadcrumbs.php
+++ b/routes/breadcrumbs.php
@@ -88,6 +88,14 @@ Breadcrumbs::for('password.change', function (BreadcrumbTrail $trail) {
     $trail->push('Ganti Password');
 });
 
+Breadcrumbs::for('backup.index', function (BreadcrumbTrail $trail) {
+    $trail->push('Backup Database', route('backup.index'));
+});
+Breadcrumbs::for('backup.show', function (BreadcrumbTrail $trail) {
+    $trail->parent('backup.index');
+    $trail->push('Download Backup');
+});
+
 Breadcrumbs::for('identitas.index', function (BreadcrumbTrail $trail) {
     $trail->push('Pengaturan Identitas', route('identitas.index'));
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,6 +91,15 @@ Route::middleware(['auth', 'teams_permission', 'password.expiry', 'password.weak
         Route::resource('activities', RiwayatPenggunaController::class)->only(['index', 'show'])->middleware('easyauthorize:pengaturan-activities');
         Route::resource('settings', App\Http\Controllers\SettingController::class)->except(['show', 'create', 'delete'])->middleware('easyauthorize:pengaturan-settings');
 
+        Route::prefix('backup')->group(function () {
+            Route::get('/', [App\Http\Controllers\BackupController::class, 'index'])->name('backup.index')->middleware('easyauthorize:pengaturan-backup');
+            Route::post('/backup', [App\Http\Controllers\BackupController::class, 'run'])->name('backup.store')->middleware('easyauthorize:pengaturan-backup');
+            Route::get('/download/{filename}', [App\Http\Controllers\BackupController::class, 'download'])->name('backup.show')->middleware('easyauthorize:pengaturan-backup');
+            Route::post('/restore/{filename}', [App\Http\Controllers\BackupController::class, 'restore'])->name('backup.update')->middleware('easyauthorize:pengaturan-backup');
+            Route::post('/upload-restore', [App\Http\Controllers\BackupController::class, 'uploadAndRestore'])->name('backup.upload')->middleware('easyauthorize:pengaturan-backup');
+            Route::delete('/{filename}', [App\Http\Controllers\BackupController::class, 'destroy'])->name('backup.destroy')->middleware('easyauthorize:pengaturan-backup');
+        });
+
         // OTP & 2FA Routes - combined into one page
         Route::prefix('otp')->group(function () {
             Route::get('/', [App\Http\Controllers\OtpController::class, 'index'])->name('otp.index');

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,13 +91,13 @@ Route::middleware(['auth', 'teams_permission', 'password.expiry', 'password.weak
         Route::resource('activities', RiwayatPenggunaController::class)->only(['index', 'show'])->middleware('easyauthorize:pengaturan-activities');
         Route::resource('settings', App\Http\Controllers\SettingController::class)->except(['show', 'create', 'delete'])->middleware('easyauthorize:pengaturan-settings');
 
-        Route::prefix('backup')->group(function () {
-            Route::get('/', [App\Http\Controllers\BackupController::class, 'index'])->name('backup.index')->middleware('easyauthorize:pengaturan-backup');
-            Route::post('/backup', [App\Http\Controllers\BackupController::class, 'run'])->name('backup.store')->middleware('easyauthorize:pengaturan-backup');
-            Route::get('/download/{filename}', [App\Http\Controllers\BackupController::class, 'download'])->name('backup.show')->middleware('easyauthorize:pengaturan-backup');
-            Route::post('/restore/{filename}', [App\Http\Controllers\BackupController::class, 'restore'])->name('backup.update')->middleware('easyauthorize:pengaturan-backup');
-            Route::post('/upload-restore', [App\Http\Controllers\BackupController::class, 'uploadAndRestore'])->name('backup.upload')->middleware('easyauthorize:pengaturan-backup');
-            Route::delete('/{filename}', [App\Http\Controllers\BackupController::class, 'destroy'])->name('backup.destroy')->middleware('easyauthorize:pengaturan-backup');
+        Route::prefix('database')->group(function () {
+            Route::get('/', [App\Http\Controllers\BackupController::class, 'index'])->name('backup.index')->middleware('easyauthorize:pengaturan-database');
+            Route::post('/backup', [App\Http\Controllers\BackupController::class, 'run'])->name('backup.store')->middleware('easyauthorize:pengaturan-database');
+            Route::get('/download/{filename}', [App\Http\Controllers\BackupController::class, 'download'])->name('backup.show')->middleware('easyauthorize:pengaturan-database');
+            Route::post('/restore/{filename}', [App\Http\Controllers\BackupController::class, 'restore'])->name('backup.update')->middleware('easyauthorize:pengaturan-database');
+            Route::post('/upload-restore', [App\Http\Controllers\BackupController::class, 'uploadAndRestore'])->name('backup.upload')->middleware('easyauthorize:pengaturan-database');
+            Route::delete('/{filename}', [App\Http\Controllers\BackupController::class, 'destroy'])->name('backup.destroy')->middleware('easyauthorize:pengaturan-database');
         });
 
         // OTP & 2FA Routes - combined into one page

--- a/tests/Feature/BackupControllerTest.php
+++ b/tests/Feature/BackupControllerTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature;
 
+use App\Http\Controllers\BackupController;
 use App\Models\User;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Permission\Models\Role;
@@ -145,5 +147,113 @@ class BackupControllerTest extends BaseTestCase
         $response->assertStatus(Response::HTTP_OK);
         $response->assertSee('backup-1.zip');
         $response->assertDontSee('notes.txt');
+    }
+
+    public function test_backup_files_stored_on_correct_disk(): void
+    {
+        $filename = 'backup-2026-07-04-12-00-00.zip';
+
+        Storage::disk($this->diskName)->put($filename, 'fake-backup-content');
+
+        Storage::disk($this->diskName)->assertExists($filename);
+
+        $backups = collect(Storage::disk($this->diskName)->files())
+            ->filter(fn (string $file): bool => str_ends_with($file, '.zip'))
+            ->values();
+
+        $this->assertCount(1, $backups);
+        $this->assertStringEndsWith('.zip', $backups[0]);
+    }
+
+    public function test_backup_index_reads_from_backups_disk(): void
+    {
+        Storage::disk($this->diskName)->put('disk-backup.zip', 'content');
+        Storage::disk('local')->put('local-backup.zip', 'content');
+
+        $response = $this->get(route('backup.index'));
+
+        $response->assertSee('disk-backup.zip');
+        $response->assertDontSee('local-backup.zip');
+    }
+
+    public function test_backup_index_returns_correct_file_metadata(): void
+    {
+        Storage::disk($this->diskName)->put('backup-test.zip', 'content');
+
+        $response = $this->get(route('backup.index'));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertViewHas('backups', function ($backups) {
+            $this->assertCount(1, $backups);
+            $this->assertEquals('backup-test.zip', $backups[0]['filename']);
+            $this->assertArrayHasKey('size', $backups[0]);
+            $this->assertArrayHasKey('last_modified', $backups[0]);
+
+            return true;
+        });
+    }
+
+    public function test_find_sql_file_with_flat_db_dumps_structure(): void
+    {
+        $tempPath = storage_path('app/backups/test_find_sql_' . uniqid());
+        mkdir($tempPath . '/db-dumps', 0755, true);
+        touch($tempPath . '/db-dumps/mysql-database.sql');
+
+        $controller = App::make(BackupController::class);
+        $reflection = new \ReflectionMethod($controller, 'findSqlFile');
+        $result = $reflection->invoke($controller, $tempPath);
+
+        $this->assertNotNull($result);
+        $this->assertStringEndsWith('mysql-database.sql', $result);
+
+        $this->cleanDir($tempPath);
+    }
+
+    public function test_find_sql_file_with_nested_db_dumps_structure(): void
+    {
+        $tempPath = storage_path('app/backups/test_find_sql_' . uniqid());
+        mkdir($tempPath . '/backup-dir/db-dumps', 0755, true);
+        touch($tempPath . '/backup-dir/db-dumps/mysql-database.sql');
+
+        $controller = App::make(BackupController::class);
+        $reflection = new \ReflectionMethod($controller, 'findSqlFile');
+        $result = $reflection->invoke($controller, $tempPath);
+
+        $this->assertNotNull($result);
+        $this->assertStringEndsWith('mysql-database.sql', $result);
+
+        $this->cleanDir($tempPath);
+    }
+
+    public function test_find_sql_file_returns_null_when_sql_missing(): void
+    {
+        $tempPath = storage_path('app/backups/test_find_sql_' . uniqid());
+        mkdir($tempPath, 0755, true);
+
+        $controller = App::make(BackupController::class);
+        $reflection = new \ReflectionMethod($controller, 'findSqlFile');
+        $result = $reflection->invoke($controller, $tempPath);
+
+        $this->assertNull($result);
+
+        rmdir($tempPath);
+    }
+
+    private function cleanDir(string $path): void
+    {
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            $file->isDir() ? @rmdir($file->getRealPath()) : @unlink($file->getRealPath());
+        }
+
+        @rmdir($path);
     }
 }

--- a/tests/Feature/BackupControllerTest.php
+++ b/tests/Feature/BackupControllerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Permission\Models\Role;
+use Tests\BaseTestCase;
+
+class BackupControllerTest extends BaseTestCase
+{    
+
+    private string $diskName = 'backups';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake($this->diskName); 
+    }
+
+    public function test_can_view_backup_index_page(): void
+    {
+        $response = $this->get(route('backup.index'));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertViewIs('backup.index');
+        $response->assertSee('Backup Database');
+    }
+
+    public function test_can_run_backup_successfully(): void
+    {
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('backup:run', ['--disable-notifications' => true])
+            ->andReturn(0);
+
+        $response = $this->postJson(route('backup.store'));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Backup berhasil dibuat.',
+        ]);
+    }
+
+    public function test_run_backup_returns_error_on_failure(): void
+    {
+        Artisan::shouldReceive('call')
+            ->once()
+            ->with('backup:run', ['--disable-notifications' => true])
+            ->andReturn(1);
+
+        Artisan::shouldReceive('output')
+            ->once()
+            ->andReturn('Database dump failed');
+
+        $response = $this->postJson(route('backup.store'));
+
+        $response->assertStatus(Response::HTTP_INTERNAL_SERVER_ERROR);
+        $response->assertJson([
+            'success' => false,
+        ]);
+    }
+
+    public function test_can_download_backup_file(): void
+    {
+        $filename = 'test-backup-2026-07-03-12-00-00.zip';
+
+        Storage::disk($this->diskName)->put($filename, 'fake-backup-content');
+
+        $response = $this->get(route('backup.show', $filename));
+
+        $response->assertStatus(Response::HTTP_OK);
+    }
+
+    public function test_download_nonexistent_backup_returns_404(): void
+    {
+        $response = $this->get(route('backup.show', 'nonexistent.zip'));
+
+        $response->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function test_download_with_invalid_filename_returns_400(): void
+    {
+        $response = $this->get(route('backup.show', 'test..backup.zip'));
+
+        $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    }
+
+    public function test_can_delete_backup_file(): void
+    {
+        $filename = 'test-backup-2026-07-03-12-00-00.zip';
+
+        Storage::disk($this->diskName)->put($filename, 'fake-backup-content');
+
+        $response = $this->deleteJson(route('backup.destroy', $filename));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertJson([
+            'success' => true,
+            'message' => 'Backup berhasil dihapus.',
+        ]);
+
+        Storage::disk($this->diskName)->assertMissing($filename);
+    }
+
+    public function test_delete_nonexistent_backup_returns_404(): void
+    {
+        $response = $this->deleteJson(route('backup.destroy', 'nonexistent.zip'));
+
+        $response->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    public function test_delete_with_invalid_filename_returns_400(): void
+    {
+        $response = $this->deleteJson(route('backup.destroy', 'test..backup.zip'));
+
+        $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    }
+
+    public function test_index_page_shows_backup_files(): void
+    {
+        Storage::disk($this->diskName)->put('backup-1.zip', 'content-1');
+        Storage::disk($this->diskName)->put('backup-2.zip', 'content-2');
+
+        $response = $this->get(route('backup.index'));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertViewIs('backup.index');
+        $response->assertSee('backup-1.zip');
+        $response->assertSee('backup-2.zip');
+    }
+
+    public function test_index_page_ignores_non_zip_files(): void
+    {
+        Storage::disk($this->diskName)->put('backup-1.zip', 'content-1');
+        Storage::disk($this->diskName)->put('notes.txt', 'not-a-backup');
+
+        $response = $this->get(route('backup.index'));
+
+        $response->assertStatus(Response::HTTP_OK);
+        $response->assertSee('backup-1.zip');
+        $response->assertDontSee('notes.txt');
+    }
+}

--- a/tests/Feature/DataPresisiKetenagakerjaanControllerTest.php
+++ b/tests/Feature/DataPresisiKetenagakerjaanControllerTest.php
@@ -103,6 +103,7 @@ class DataPresisiKetenagakerjaanControllerTest extends BaseTestCase
             'alamat' => 'Jl. Test No. 1',
             'jumlah_anggota' => 4,
             'jumlah_kk' => 1,
+            'tahun' => '',
         ]);
 
         $response = $this->get(route('data-pokok.data-presisi-ketenagakerjaan.detail', ['data' => $data]));
@@ -121,6 +122,7 @@ class DataPresisiKetenagakerjaanControllerTest extends BaseTestCase
             'alamat' => 'Jl. Test No. 1',
             'jumlah_anggota' => 4,
             'jumlah_kk' => 1,
+            'tahun' => '',
         ]);
 
         $response = $this->get(route('data-pokok.data-presisi-ketenagakerjaan.detail', ['data' => $data]));
@@ -146,6 +148,7 @@ class DataPresisiKetenagakerjaanControllerTest extends BaseTestCase
             'alamat' => 'Jl. Test',
             'jumlah_anggota' => 3,
             'jumlah_kk' => 1,
+            'tahun' => '',
         ]);
 
         $response = $this->get(route('data-pokok.data-presisi-ketenagakerjaan.detail', ['data' => $data]));
@@ -166,6 +169,7 @@ class DataPresisiKetenagakerjaanControllerTest extends BaseTestCase
             'alamat' => 'Jl. Test',
             'jumlah_anggota' => 3,
             'jumlah_kk' => 1,
+            'tahun' => '',
         ]);
 
         $response = $this->get(route('data-pokok.data-presisi-ketenagakerjaan.detail', ['data' => $data]));
@@ -185,6 +189,7 @@ class DataPresisiKetenagakerjaanControllerTest extends BaseTestCase
             'alamat' => 'Jl. Test',
             'jumlah_anggota' => 3,
             'jumlah_kk' => 1,
+            'tahun' => '',
         ]);
 
         $response = $this->get(route('data-pokok.data-presisi-ketenagakerjaan.detail', ['data' => $data]));

--- a/tests/Unit/DataPresisiPanganDetailViewTest.php
+++ b/tests/Unit/DataPresisiPanganDetailViewTest.php
@@ -52,8 +52,8 @@ class DataPresisiPanganDetailViewTest extends BaseTestCase
         $html = $view->render();
 
         // Assert bahwa JavaScript DataTable configuration mengandung mapping untuk longitude dan latitude
-        $this->assertStringContainsString("{ data: 'attributes.longitude', orderable: false }", $html);
-        $this->assertStringContainsString("{ data: 'attributes.latitude', orderable: false }", $html);
+        $this->assertStringContainsString("{ data: 'attributes.longitude', defaultContent: \"-\", orderable: false }", $html);
+        $this->assertStringContainsString("{ data: 'attributes.latitude', defaultContent: \"-\", orderable: false }", $html);
         
         // Assert bahwa koordinat dikonfigurasi sebagai kolom yang tidak dapat diurutkan
         $this->assertStringContainsString("orderable: false", $html);
@@ -103,11 +103,11 @@ class DataPresisiPanganDetailViewTest extends BaseTestCase
         $view = ViewFacade::make('data_pokok.data_presisi.pangan.detail', ['data' => $mockData]);
         $html = $view->render();
 
-        // Assert bahwa filter API menggunakan rtm_id yang benar untuk mengambil data koordinat
-        $this->assertStringContainsString('url.searchParams.set("filter[rtm_id]", "TEST_RTM_123")', $html);
+        // Assert bahwa filter API menggunakan id_rtm (no_kartu_rumah) yang benar untuk mengambil data koordinat
+        $this->assertStringContainsString('url.searchParams.set("filter[id_rtm]", "KRT001")', $html);
         
         // Assert bahwa endpoint API untuk data presisi pangan dikonfigurasi dengan benar
-        $this->assertStringContainsString('/api/v1/data-presisi/pangan', $html);
+        $this->assertStringContainsString('/api/v1/data-presisi/pangan/anggota', $html);
     }
 
     #[Test]
@@ -242,8 +242,8 @@ class DataPresisiPanganDetailViewTest extends BaseTestCase
 
         // Assert bahwa longitude dan latitude dikonfigurasi sebagai non-orderable
         // Ini penting karena koordinat biasanya tidak perlu diurutkan
-        $this->assertStringContainsString("{ data: 'attributes.longitude', orderable: false }", $html);
-        $this->assertStringContainsString("{ data: 'attributes.latitude', orderable: false }", $html);
+        $this->assertStringContainsString("{ data: 'attributes.longitude', defaultContent: \"-\", orderable: false }", $html);
+        $this->assertStringContainsString("{ data: 'attributes.latitude', defaultContent: \"-\", orderable: false }", $html);
         
         // Assert bahwa semua kolom selain nomor urut dikonfigurasi sebagai non-orderable
         $columnDefPattern = '/targets: \[0, 1, 2, 3, 4, 5\],\s*orderable: false,\s*searchable: false/';


### PR DESCRIPTION
# Pull Request: Fitur Backup & Restore Database dan Storage

## Description

Menambahkan fitur backup dan restore database serta file asset (storage) pada halaman Pengaturan Aplikasi. Fitur ini memudahkan proses migrasi server atau instalasi ulang dengan tetap menjaga data lama dapat sepenuhnya dipindahkan ke aplikasi baru. Menggunakan package `spatie/laravel-backup` untuk proses backup, dan menyediakan mekanisme restore dari file backup yang tersimpan maupun upload file backup.

### Changes made:

1. **New Controller** (`app/Http/Controllers/BackupController.php`): Controller untuk mengelola backup — index, run, download, delete, restore, dan upload+restore. Menggunakan trait `UploadedFile` untuk upload file.
2. **New FormRequest** (`app/Http/Requests/RestoreBackupRequest.php`): Validasi upload file backup (required, file, mimes:zip, max 50MB).
3. **New View** (`resources/views/backup/index.blade.php`): Halaman manajemen backup dengan tabel daftar backup, tombol Backup Sekarang, Upload & Restore, serta aksi download/restore/hapus per file.
4. **New Routes** (`routes/web.php`): 6 route untuk backup (`index`, `store`, `show`, `update`, `upload`, `destroy`) di prefix `pengaturan/backup`.
5. **New Migrations**: Menu navigasi Database di modul Pengaturan Aplikasi + 4 permission (`pengaturan-database-{read,write,edit,delete}`) yang diberikan ke role administrator.
6. **New Package** (`composer.json`): Menambahkan `spatie/laravel-backup ^10.3`.
7. **New Config** (`config/backup.php`): Konfigurasi backup — sumber (database + storage/app), tujuan (disk `backups`), notifikasi, dan strategi pembersihan.
8. **Modified Config** (`config/filesystems.php`): Menambahkan disk `backups` dengan root `storage/app/backups/{APP_NAME}`.
9. **Modified Menu** (`app/Enums/Modul.php`): Menambahkan submenu "Database" di grup Pengaturan.
10. **Modified Middleware** (`app/Http/Middleware/EasyAuthorize.php`): Menambahkan mapping `'upload' => 'write'` untuk permission.
11. **Modified Breadcrumbs** (`routes/breadcrumbs.php`): Menambahkan breadcrumb untuk halaman backup.
12. **New Tests** (`tests/Feature/BackupControllerTest.php`): 11 test cases mencakup index, run, download, delete, dan edge cases.
13. **Translation Files** (`lang/vendor/backup/*/notifications.php`): 24 file notifikasi dari Spatie Backup untuk berbagai bahasa, termasuk bahasa Indonesia.

### Reason for change:

- **Kebutuhan migrasi**: Saat server perlu dipindah atau diinstal ulang, data lama harus bisa dipindahkan sepenuhnya.
- **Belum ada fitur backup/restore**: OpenKab sebelumnya tidak memiliki mekanisme backup dan restore database maupun file asset.
- **Kemudahan pemulihan**: Dengan fitur ini, administrator dapat dengan mudah membuat backup rutin, mendownload, merestore dari backup yang ada, atau upload file backup dari server lain.

### Impact of change:

✅ **Fitur baru**: Admin dapat membuat, melihat, mengunduh, dan menghapus backup database + storage.
✅ **Restore fleksibel**: Bisa restore dari backup yang tersimpan di sistem, maupun upload file backup.zip untuk skenario pindah server.
✅ **Keamanan**: Validasi server-side (mimes:zip, max size), proteksi Zip Slip, file dipindah dari public path sebelum diproses.
✅ **Pengaturan permission**: 4 permission terintegrasi dengan sistem EasyAuthorize yang sudah ada.

## Related Issue

- Closes #1085

## Steps to Reproduce

### Sebelum fitur:
1. Buka menu Pengaturan
2. Tidak ada submenu Backup Database
3. ❌ Tidak ada cara untuk backup/restore data

### Setelah fitur:
1. Buka menu Pengaturan → Backup Database
2. Klik "Backup Sekarang" untuk membuat backup baru
3. Backup muncul di tabel dengan info nama file, ukuran, dan tanggal
4. Klik icon Download untuk mengunduh file backup
5. Klik icon Restore untuk mengembalikan data dari backup tertentu
6. Klik icon Hapus untuk menghapus backup
7. Klik "Upload & Restore" untuk upload file backup dari server lain
8. ✅ Data berhasil dibackup dan direstore

## Checklist

- [x] I have complied with script writing rules
- [x] I have followed pull request review process
- [x] I have created unit test/integration test to verify the fix
- [x] Manual testing has been done in development environment
- [x] No console errors or warnings

## Technical Details

### Arsitektur Backup

- Backup menggunakan `spatie/laravel-backup` via `php artisan backup:run`
- Sumber backup: semua koneksi database (default mysql) + `storage/app/`
- Tujuan backup: disk `backups` → `storage/app/backups/{APP_NAME}/`
- File backup: ZIP berisi SQL dump + folder `storage/app/`

### Arsitektur Restore

- Restore dari backup yang tersimpan: Buka ZIP → ekstrak ke temp → restore SQL via `DB::unprepared()` → copy `storage/app/` dari backup
- Restore dari upload: Upload file → validasi mimes:zip dengan FormRequest → simpan via trait `UploadedFile` → pindah ke temp non-public → ekstrak → restore
- Dilengkapi proteksi Zip Slip dengan validasi entry path sebelum ekstraksi
- File upload dihapus setelah restore selesai

### Permission Mapping

| Route | Permission |
|-------|-----------|
| `backup.index` | `pengaturan-database-read` |
| `backup.store` | `pengaturan-database-write` |
| `backup.show` | `pengaturan-database-read` |
| `backup.update` | `pengaturan-database-edit` |
| `backup.upload` | `pengaturan-database-write` |
| `backup.destroy` | `pengaturan-database-delete` |

### Configuration changes

- `config/filesystems.php`: Menambahkan disk `backups`
- `config/backup.php`: File konfigurasi baru untuk Spatie Backup

### Dependencies added

- `spatie/laravel-backup`: ^10.3

## Testing

### Manual Testing

- [x] Membuat backup via tombol "Backup Sekarang"
- [x] Melihat daftar backup di tabel
- [x] Mendownload file backup
- [x] Restore dari backup yang ada
- [x] Upload file backup dan restore
- [x] Menghapus backup
- [x] Validasi error untuk file non-zip
- [x] Validasi error untuk filename tidak valid (path traversal)
- [x] Permission check untuk setiap aksi

### Automated Testing

- 11 unit test di `tests/Feature/BackupControllerTest.php`
- Test mencakup: index page, run backup success/failure, download (valid/nonexistent/invalid filename), delete (success/nonexistent/invalid filename), index menampilkan file, index mengabaikan non-zip

## Breaking Changes

None. Fitur baru, tidak mengubah perilaku existing.

## Migration Guide

Tidak diperlukan migrasi khusus. Jalankan `php artisan migrate` untuk menambahkan menu dan permission. Jalankan `composer install` untuk menginstall package baru.

## Video


https://github.com/user-attachments/assets/0b003a3e-05d5-496e-8709-72d6c9556c6a


