### PR TITLE
fix: register MenuListener manually for Laravel 13 compatibility

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,12 +4,14 @@ namespace App\Providers;
 
 use App\Http\Transformers\IdentitasTransformer;
 use App\Http\Transformers\SettingTransformer;
+use App\Listeners\MenuListener;
 use App\Models\Identitas;
 use App\Models\Setting;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\URL;
@@ -19,6 +21,7 @@ use Illuminate\Support\ServiceProvider;
 use App\Observers\VisitorObserver;
 use Exception;
 use Illuminate\Support\Facades\Log;
+use JeroenNoten\LaravelAdminLte\Events\BuildingMenu;
 use Shetabit\Visitor\Models\Visit;
 
 class AppServiceProvider extends ServiceProvider
@@ -43,7 +46,8 @@ class AppServiceProvider extends ServiceProvider
         $this->bootHttps();
         $this->addValidation();
         $this->addLogQuery();
-        
+        $this->registerMenuListener();
+
         try {
             $this->shareViewIdentitas();
         } catch (Exception $e) {
@@ -75,6 +79,15 @@ class AppServiceProvider extends ServiceProvider
         if (App::runningInConsole()) {
             activity()->disableLogging();
         }
+    }
+
+    /**
+     * Register MenuListener for BuildingMenu event.
+     * Required for Laravel 11+ where vendor event auto-discovery may not work.
+     */
+    private function registerMenuListener(): void
+    {
+        Event::listen(BuildingMenu::class, MenuListener::class);
     }
 
     private function shareViewIdentitas(): void


### PR DESCRIPTION
## Deskripsi

PR ini memperbaiki masalah di mana menu sidebar hanya menampilkan 2 item (Dasbor dan Dasbor Demografi) setelah migrasi ke Laravel 13.

## Root Cause

Di Laravel 13, event auto-discovery **tidak menemukan** BuildingMenu event dari package vendor (jeroennoten/laravel-adminlte). MenuListener yang seharusnya load menu dari tabel 	eam ke sidebar tidak pernah di-trigger.

### Bukti

`ash
$ php artisan event:list | grep Building
# (kosong - BuildingMenu tidak terdaftar)
`

## Perubahan

File: pp/Providers/AppServiceProvider.php

- Added use App\Listeners\MenuListener;
- Added use Illuminate\Support\Facades\Event;
- Added use JeroenNoten\LaravelAdminLte\Events\BuildingMenu;
- Added $this->registerMenuListener(); in oot() method
- Added new egisterMenuListener() method

`php
private function registerMenuListener(): void
{
    Event::listen(BuildingMenu::class, MenuListener::class);
}
`

## Testing

1. Jalankan php artisan event:list | grep Building - harusnya sekarang muncul:
   `
   JeroenNoten\LaravelAdminLte\Events\BuildingMenu
     ⇂ App\Listeners\MenuListener
   `
2. Login ke admin panel
3. Menu sidebar harus menampilkan semua menu dari konfigurasi team (Profile Kependudukan, Statistik, Laporan, Pengaturan, dll)

Fixes #1087