### PR TITLE
Feat: history password

### DIFF
--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -4,10 +4,8 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ResetPasswordRequest;
-use App\Models\PasswordHistory;
 use App\Providers\AppServiceProvider;
 use Illuminate\Foundation\Auth\ResetsPasswords;
-use Illuminate\Support\Facades\Password;
 
 class ResetPasswordController extends Controller
 {
@@ -75,26 +73,14 @@ class ResetPasswordController extends Controller
     {
         $expiryDays = config('password.expiry_days');
 
-        // Save old password to history
-        if ($user->password) {
-            PasswordHistory::create([
-                'user_id' => $user->id,
-                'password' => $user->password,
-                'reason' => 'password_reset',
-            ]);
-        }
-
-        // Set new password
+        $user->passwordHistoryReason = 'password_reset';
         $user->password = $password;
 
-        // Set expiry if configured
         if ($expiryDays) {
             $user->password_expires_at = now()->addDays($expiryDays);
         }
 
-        // Reset force_password_reset flag
         $user->force_password_reset = false;
-
         $user->save();
     }
 }

--- a/app/Http/Controllers/ForcePasswordResetController.php
+++ b/app/Http/Controllers/ForcePasswordResetController.php
@@ -3,7 +3,6 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\ForcePasswordResetRequest;
-use App\Models\PasswordHistory;
 use App\Providers\AppServiceProvider;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -39,22 +38,13 @@ class ForcePasswordResetController extends Controller
 
         $expiryDays = config('password.expiry_days');
 
-        // Save old password to history
-        PasswordHistory::create([
-            'user_id' => $user->id,
-            'password' => $user->password,
-            'reason' => 'forced_reset_completed',
-        ]);
-
-        // Set new password
+        $user->passwordHistoryReason = 'forced_reset_completed';
         $user->password = $request->password;
 
-        // Set expiry if configured
         if ($expiryDays) {
             $user->password_expires_at = now()->addDays($expiryDays);
         }
 
-        // Reset force_password_reset flag
         $user->force_password_reset = false;
         $user->save();
 

--- a/app/Http/Requests/ChangePasswordRequest.php
+++ b/app/Http/Requests/ChangePasswordRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use App\Rules\MatchOldPassword;
 use App\Rules\StrongPassword;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ChangePasswordRequest extends FormRequest
@@ -14,6 +15,16 @@ class ChangePasswordRequest extends FormRequest
     public function authorize(): bool
     {
         return auth()->check();
+    }
+
+    /**
+     * Handle a failed validation attempt.
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        session()->flash('error', $validator->errors()->first());
+
+        parent::failedValidation($validator);
     }
 
     /**

--- a/app/Http/Requests/ResetPasswordRequest.php
+++ b/app/Http/Requests/ResetPasswordRequest.php
@@ -22,10 +22,15 @@ class ResetPasswordRequest extends FormRequest
      */
     public function rules(): array
     {
+        $user = null;
+        if ($this->has('email')) {
+            $user = \App\Models\User::where('email', $this->input('email'))->first();
+        }
+
         return [
             'token' => ['required'],
             'email' => ['required', 'email'],
-            'password' => ['required', 'string', 'confirmed', new StrongPassword()],
+            'password' => ['required', 'string', 'confirmed', new StrongPassword(user: $user)],
         ];
     }
 

--- a/app/Http/Requests/ResetPasswordRequest.php
+++ b/app/Http/Requests/ResetPasswordRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Rules\StrongPassword;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ResetPasswordRequest extends FormRequest
@@ -13,6 +14,16 @@ class ResetPasswordRequest extends FormRequest
     public function authorize(): bool
     {
         return true;
+    }
+
+    /**
+     * Handle a failed validation attempt.
+     */
+    protected function failedValidation(Validator $validator): void
+    {
+        session()->flash('error', $validator->errors()->first());
+
+        parent::failedValidation($validator);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -127,6 +127,9 @@ class User extends Authenticatable
         return parent::delete();
     }
 
+    public ?string $passwordHistoryReason = null;
+    public ?string $oldPasswordHash = null;
+
     public function team()
     {
         return $this->belongsToMany(
@@ -265,27 +268,19 @@ class User extends Authenticatable
     }
 
     /**
-     * Set password dengan expiry dan history
+     * Set password dengan expiry.
+     * Riwayat password lama otomatis disimpan oleh UserObserver.
      */
     public function setPasswordWithHistory(string $password, string $reason = 'password_change', ?int $expiryDays = null): void
     {
-        // Simpan password lama ke history
-        if ($this->exists && $this->password) {
-            $this->passwordHistory()->create([
-                'password' => $this->password,
-                'reason' => $reason,
-            ]);
-        }
+        $this->passwordHistoryReason = $reason;
 
-        // Set password baru
         $this->password = $password;
 
-        // Set expiry jika ditentukan
         if ($expiryDays !== null) {
             $this->password_expires_at = now()->addDays($expiryDays);
         }
 
-        // Reset flag force_password_reset
         $this->force_password_reset = false;
 
         $this->save();

--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class UserObserver
+{
+    public function saving(User $user): void
+    {
+        if ($user->exists && $user->isDirty('password')) {
+            $user->oldPasswordHash = $user->getOriginal('password');
+        }
+    }
+
+    public function saved(User $user): void
+    {
+        if (!isset($user->oldPasswordHash)) {
+            return;
+        }
+
+        DB::transaction(function () use ($user) {
+            $reason = $user->passwordHistoryReason ?? 'password_change';
+
+            $user->passwordHistory()->create([
+                'password' => $user->oldPasswordHash,
+                'reason' => $reason,
+            ]);
+
+            $historyCount = config('password.history_count', 10);
+            if ($historyCount > 0) {
+                $recentIds = $user->passwordHistory()
+                    ->orderBy('created_at', 'desc')
+                    ->limit($historyCount)
+                    ->pluck('id');
+
+                $user->passwordHistory()
+                    ->whereNotIn('id', $recentIds)
+                    ->delete();
+            }
+        });
+
+        $user->oldPasswordHash = null;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -16,6 +16,8 @@ use Illuminate\Support\Facades\URL;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
+use App\Models\User;
+use App\Observers\UserObserver;
 use App\Observers\VisitorObserver;
 use Exception;
 use Illuminate\Support\Facades\Log;
@@ -104,6 +106,7 @@ class AppServiceProvider extends ServiceProvider
 
     protected function configureObservers(): void
     {
+        User::observe(UserObserver::class);
         Visit::observe(VisitorObserver::class);
     }
 

--- a/app/Rules/StrongPassword.php
+++ b/app/Rules/StrongPassword.php
@@ -42,6 +42,11 @@ class StrongPassword implements Rule
     protected array $commonPasswords;
 
     /**
+     * The validation rule that failed.
+     */
+    protected ?string $failedRule = null;
+
+    /**
      * Create a new rule instance.
      */
     public function __construct(
@@ -68,48 +73,48 @@ class StrongPassword implements Rule
      */
     public function passes($attribute, $value)
     {
-        // Check minimum length
         if (strlen($value) < $this->minLength) {
+            $this->failedRule = 'length';
             return false;
         }
 
-        // Check for at least one uppercase letter
         if (!preg_match('/[A-Z]/', $value)) {
+            $this->failedRule = 'complexity';
             return false;
         }
 
-        // Check for at least one lowercase letter
         if (!preg_match('/[a-z]/', $value)) {
+            $this->failedRule = 'complexity';
             return false;
         }
 
-        // Check for at least one number
         if (!preg_match('/[0-9]/', $value)) {
+            $this->failedRule = 'complexity';
             return false;
         }
 
-        // Check for at least one special character
         if (!preg_match('/[!@#$%^&*(),.?":{}|<>_\-+=\[\]\\;\'\/`~]/', $value)) {
+            $this->failedRule = 'complexity';
             return false;
         }
 
-        // Check for weak patterns
         if ($this->matchesWeakPattern($value)) {
+            $this->failedRule = 'weak_pattern';
             return false;
         }
 
-        // Check for common passwords
         if ($this->isCommonPassword($value)) {
+            $this->failedRule = 'common';
             return false;
         }
 
-        // Check HIBP database
         if ($this->checkHibp && !$this->isNotPwned($value)) {
+            $this->failedRule = 'hibp';
             return false;
         }
 
-        // Check password history
         if (!$this->isNotInHistory($value)) {
+            $this->failedRule = 'history';
             return false;
         }
 
@@ -203,14 +208,20 @@ class StrongPassword implements Rule
      */
     public function message()
     {
-        return [
-            'length' => 'Password harus memiliki minimal :min karakter.',
+        $messages = [
+            'length' => 'Password harus memiliki minimal '.$this->minLength.' karakter.',
             'complexity' => 'Password harus mengandung huruf kapital, huruf kecil, angka, dan karakter spesial (!@#$%^&*...).',
             'hibp' => 'Password ini telah bocor di database password yang pernah diretas. Silakan gunakan password lain yang lebih unik.',
             'history' => 'Password ini telah digunakan sebelumnya. Silakan gunakan password baru.',
             'weak_pattern' => 'Password terlalu lemah atau mudah ditebak. Hindari pola berulang atau berurutan.',
             'common' => 'Password ini terlalu umum dan mudah ditebak. Silakan gunakan password yang lebih unik.',
         ];
+
+        if ($this->failedRule && isset($messages[$this->failedRule])) {
+            return $messages[$this->failedRule];
+        }
+
+        return 'Password tidak memenuhi persyaratan keamanan.';
     }
 
     /**

--- a/app/Rules/StrongPassword.php
+++ b/app/Rules/StrongPassword.php
@@ -3,6 +3,7 @@
 namespace App\Rules;
 
 use App\Models\PasswordHistory;
+use App\Models\User;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
@@ -31,6 +32,11 @@ class StrongPassword implements Rule
     protected array $weakPatterns;
 
     /**
+     * Specific user to check history against (for unauthenticated contexts).
+     */
+    protected ?User $user = null;
+
+    /**
      * Common passwords list.
      */
     protected array $commonPasswords;
@@ -41,13 +47,15 @@ class StrongPassword implements Rule
     public function __construct(
         ?int $minLength = null,
         ?bool $checkHibp = null,
-        ?int $historySize = null
+        ?int $historySize = null,
+        ?User $user = null
     ) {
         $this->minLength = $minLength ?? config('password.min_length', 12);
         $this->checkHibp = $checkHibp ?? config('password.check_hibp', true);
-        $this->historySize = $historySize ?? config('password.history_count', 5);
+        $this->historySize = $historySize ?? config('password.history_count', 10);
         $this->weakPatterns = config('password.weak_patterns', []);
         $this->commonPasswords = config('password.common_passwords', []);
+        $this->user = $user;
     }
 
     /**
@@ -168,11 +176,12 @@ class StrongPassword implements Rule
      */
     protected function isNotInHistory(string $password): bool
     {
-        if (!auth()->check()) {
-            return true; // No logged in user to check history for
+        $user = $this->user ?? (auth()->check() ? auth()->user() : null);
+
+        if (!$user) {
+            return true;
         }
 
-        $user = auth()->user();
         $passwordHistory = PasswordHistory::where('user_id', $user->id)
             ->orderBy('created_at', 'desc')
             ->limit($this->historySize)

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -14,5 +14,6 @@ Di rilis ini, versi 2607.0.0 berisi penambahan dan perbaikan yang diminta penggu
 
 #### Perubahan Teknis
 
+1. [#1095](https://github.com/OpenSID/OpenKab/issues/1095) Terapkan Password History (10 Kata Sandi Terakhir).
 
 

--- a/config/password.php
+++ b/config/password.php
@@ -42,7 +42,7 @@ return [
     | Set to 0 to disable password history check.
     |
     */
-    'history_count' => 5,
+    'history_count' => 10,
 
     /*
     |--------------------------------------------------------------------------

--- a/tests/Feature/LoginControllerTest.php
+++ b/tests/Feature/LoginControllerTest.php
@@ -55,9 +55,7 @@ class LoginControllerTest extends TestCase
         $this->app->instance(TwoFactorService::class, $this->twoFactorService);
 
         // Clear any existing rate limiters
-        $userAgent = $this->app['request']->userAgent() ?? 'unknown';
-        $ip = '127.0.0.1';
-        RateLimiter::clear("captcha:{$ip}:" . hash('xxh64', $userAgent));
+        RateLimiter::clear('captcha:127.0.0.1:' . hash('xxh64', 'Symfony'));
     }
 
     #[Test]
@@ -74,9 +72,18 @@ class LoginControllerTest extends TestCase
     #[Test]
     public function it_shows_login_form_with_captcha_when_threshold_reached()
     {
-        // Simulate failed attempts to trigger captcha
-        $key = 'captcha:127.0.0.1:' . hash('xxh64', $this->app['request']->userAgent() ?? 'unknown');
-        RateLimiter::clear($key); // Clear first to ensure clean state
+        // Ensure captcha is enabled for this test
+        \App\Models\Setting::updateOrCreate(
+            ['key' => 'captcha_enabled'],
+            ['value' => '1']
+        );
+        \App\Models\Setting::updateOrCreate(
+            ['key' => 'captcha_threshold'],
+            ['value' => '2']
+        );
+
+        $key = 'captcha:127.0.0.1:' . hash('xxh64', 'Symfony');
+        RateLimiter::clear($key);
         RateLimiter::hit($key);
         RateLimiter::hit($key);
         RateLimiter::hit($key);
@@ -384,11 +391,8 @@ class LoginControllerTest extends TestCase
 
     protected function tearDown(): void
     {
-        // Clean up rate limiters
-        $userAgent = $this->app['request']->userAgent() ?? 'unknown';
-        $ip = '127.0.0.1';
-        RateLimiter::clear("captcha:{$ip}:" . hash('xxh64', $userAgent));
-        
+        RateLimiter::clear('captcha:127.0.0.1:' . hash('xxh64', 'Symfony'));
+
         parent::tearDown();
     }
 }

--- a/tests/Feature/OtpLoginControllerTest.php
+++ b/tests/Feature/OtpLoginControllerTest.php
@@ -48,12 +48,16 @@ class OtpLoginControllerTest extends TestCase
         $this->app->instance(OtpService::class, $this->otpService);
         $this->app->instance(TwoFactorService::class, $this->twoFactorService);
 
+        // Ensure consistent user agent for rate limiter keys.
+        // Request::create() defaults HTTP_USER_AGENT to 'Symfony', but the
+        // app request in CLI context may have null UA.
+        $this->app['request']->server->set('HTTP_USER_AGENT', 'Symfony');
+
         // Clear any existing rate limiters
-        $userAgent = $this->app['request']->userAgent() ?? 'unknown';
-        RateLimiter::clear('captcha:127.0.0.1:' . hash('xxh64', $userAgent));
-        RateLimiter::clear('otp:login:test@example.com:127.0.0.1:' . hash('xxh64', $userAgent));
-        RateLimiter::clear('otp:verify:' . $this->user->id . ':127.0.0.1:' . hash('xxh64', $userAgent));
-        RateLimiter::clear('otp:resend:' . $this->user->id . ':127.0.0.1:' . hash('xxh64', $userAgent));
+        RateLimiter::clear('captcha:127.0.0.1:' . hash('xxh64', 'Symfony'));
+        RateLimiter::clear('otp:login:test@example.com:127.0.0.1:' . hash('xxh64', 'Symfony'));
+        RateLimiter::clear('otp:verify:' . $this->user->id . ':127.0.0.1:' . hash('xxh64', 'Symfony'));
+        RateLimiter::clear('otp:resend:' . $this->user->id . ':127.0.0.1:' . hash('xxh64', 'Symfony'));
     }
 
     #[Test]
@@ -70,8 +74,17 @@ class OtpLoginControllerTest extends TestCase
     #[Test]
     public function it_shows_otp_login_form_with_captcha_when_threshold_reached()
     {
-        // Simulate failed attempts to trigger captcha
-        $key = 'captcha:127.0.0.1:' . hash('xxh64', $this->app['request']->userAgent() ?? 'unknown');
+        // Ensure captcha is enabled for this test
+        \App\Models\Setting::updateOrCreate(
+            ['key' => 'captcha_enabled'],
+            ['value' => '1']
+        );
+        \App\Models\Setting::updateOrCreate(
+            ['key' => 'captcha_threshold'],
+            ['value' => '2']
+        );
+
+        $key = 'captcha:127.0.0.1:' . hash('xxh64', 'Symfony');
         RateLimiter::clear($key);
         RateLimiter::hit($key);
         RateLimiter::hit($key);

--- a/tests/Feature/PasswordHistoryTest.php
+++ b/tests/Feature/PasswordHistoryTest.php
@@ -1,0 +1,128 @@
+<?php
+
+use App\Models\PasswordHistory;
+use App\Models\User;
+use App\Observers\UserObserver;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Hash;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create([
+        'password' => 'OldP@ssw0rd123!',
+    ]);
+});
+
+it('stores old password hash in password_histories when password is changed', function () {
+    $this->user->password = 'NewP@ssw0rd456!';
+    $this->user->save();
+
+    $this->assertDatabaseHas('password_histories', [
+        'user_id' => $this->user->id,
+        'reason' => 'password_change',
+    ]);
+
+    $history = PasswordHistory::where('user_id', $this->user->id)->first();
+    expect(Hash::check('OldP@ssw0rd123!', $history->password))->toBeTrue();
+});
+
+it('uses custom reason when passwordHistoryReason is set', function () {
+    $this->user->passwordHistoryReason = 'custom_reason';
+    $this->user->password = 'NewP@ssw0rd456!';
+    $this->user->save();
+
+    $this->assertDatabaseHas('password_histories', [
+        'user_id' => $this->user->id,
+        'reason' => 'custom_reason',
+    ]);
+});
+
+it('does not store history for new users', function () {
+    $newUser = User::factory()->create([
+        'password' => 'FirstP@ssw0rd!',
+    ]);
+
+    expect(PasswordHistory::where('user_id', $newUser->id)->count())->toBe(0);
+});
+
+it('does not store history when password is not changed', function () {
+    $this->user->name = 'Updated Name';
+    $this->user->save();
+
+    expect(PasswordHistory::where('user_id', $this->user->id)->count())->toBe(0);
+});
+
+it('prunes old history entries beyond the configured limit', function () {
+    $historyCount = config('password.history_count', 10);
+
+    for ($i = 0; $i < $historyCount; $i++) {
+        $this->user->passwordHistory()->create([
+            'password' => Hash::make("OldP@ssw0rd{$i}!"),
+            'reason' => 'password_change',
+        ]);
+    }
+
+    expect(PasswordHistory::where('user_id', $this->user->id)->count())->toBe($historyCount);
+
+    $this->user->password = 'NewP@ssw0rdLatest!';
+    $this->user->save();
+
+    $remaining = PasswordHistory::where('user_id', $this->user->id)->count();
+    expect($remaining)->toBe($historyCount)
+        ->and($remaining)->toBeLessThanOrEqual($historyCount);
+});
+
+it('resets oldPasswordHash to null after processing', function () {
+    $observer = new UserObserver;
+
+    $observer->saving($this->user);
+    expect(isset($this->user->oldPasswordHash))->toBeFalse();
+
+    $this->user->password = 'NewP@ssw0rd456!';
+
+    $observer->saving($this->user);
+    expect(isset($this->user->oldPasswordHash))->toBeTrue();
+
+    $this->user->passwordHistoryReason = 'test';
+    $observer->saved($this->user);
+    expect(isset($this->user->oldPasswordHash))->toBeFalse();
+});
+
+it('stores history with correct user context', function () {
+    $otherUser = User::factory()->create([
+        'password' => 'OtherP@ss!1234',
+    ]);
+
+    $this->user->password = 'NewP@ssw0rd456!';
+    $this->user->save();
+
+    $otherUser->password = 'OtherNewP@ss!5678';
+    $otherUser->save();
+
+    expect(PasswordHistory::where('user_id', $this->user->id)->count())->toBe(1);
+    expect(PasswordHistory::where('user_id', $otherUser->id)->count())->toBe(1);
+});
+
+it('prunes only current user history entries', function () {
+    $otherUser = User::factory()->create([
+        'password' => 'OtherP@ss!1234',
+    ]);
+
+    for ($i = 0; $i < 10; $i++) {
+        $this->user->passwordHistory()->create([
+            'password' => Hash::make("OldP@ssw0rd{$i}!"),
+            'reason' => 'password_change',
+        ]);
+        $otherUser->passwordHistory()->create([
+            'password' => Hash::make("OtherOldP@ss{$i}!"),
+            'reason' => 'password_change',
+        ]);
+    }
+
+    $this->user->password = 'NewP@ssw0rdLatest!';
+    $this->user->save();
+
+    expect(PasswordHistory::where('user_id', $this->user->id)->count())->toBe(10);
+    expect(PasswordHistory::where('user_id', $otherUser->id)->count())->toBe(10);
+});

--- a/tests/Feature/PasswordResetFlowTest.php
+++ b/tests/Feature/PasswordResetFlowTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Models\PasswordHistory;
+use App\Models\User;
+use App\Providers\AppServiceProvider;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Hash;
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    config(['password.check_hibp' => false]);
+    $this->user = User::factory()->create([
+        'email' => 'test@example.com',
+        'password' => 'CurrentP@ssw0rd!',
+        'force_password_reset' => true,
+        'password_expires_at' => null,
+    ]);
+});
+
+it('shows force password reset form when user requires reset', function () {
+    $this->actingAs($this->user)
+        ->get(route('password.reset.form'))
+        ->assertStatus(200)
+        ->assertViewIs('auth.force-password-reset');
+});
+
+it('redirects from force password reset form when user does not require reset', function () {
+    $this->user->update(['force_password_reset' => false]);
+
+    $this->actingAs($this->user)
+        ->get(route('password.reset.form'))
+        ->assertRedirect(route('dasbor'));
+});
+
+it('processes force password reset successfully', function () {
+    $this->actingAs($this->user)
+        ->post(route('password.reset.force'), [
+            'password' => 'Str0ng!NewP@ssword',
+            'password_confirmation' => 'Str0ng!NewP@ssword',
+        ])
+        ->assertRedirect(AppServiceProvider::HOME)
+        ->assertSessionHas('success');
+
+    $this->user->refresh();
+    expect($this->user->force_password_reset)->toBeFalse();
+    expect($this->user->password_expires_at)->not->toBeNull();
+});
+
+it('stores old password to history on force reset', function () {
+    $this->actingAs($this->user)
+        ->post(route('password.reset.force'), [
+            'password' => 'Str0ng!NewP@ssword',
+            'password_confirmation' => 'Str0ng!NewP@ssword',
+        ]);
+
+    $history = PasswordHistory::where('user_id', $this->user->id)->first();
+    expect($history)->not->toBeNull();
+    expect($history->reason)->toBe('forced_reset_completed');
+    expect(Hash::check('CurrentP@ssw0rd!', $history->password))->toBeTrue();
+});
+
+it('rejects reused password in force reset', function () {
+    $this->user->passwordHistory()->create([
+        'password' => Hash::make('Str0ng!N3wP@ssword'),
+        'reason' => 'password_change',
+    ]);
+
+    $this->actingAs($this->user)
+        ->post(route('password.reset.force'), [
+            'password' => 'Str0ng!N3wP@ssword',
+            'password_confirmation' => 'Str0ng!N3wP@ssword',
+        ])
+        ->assertSessionHasErrors();
+});
+
+it('redirects from force reset when user does not require reset', function () {
+    $this->user->update(['force_password_reset' => false]);
+
+    $this->actingAs($this->user)
+        ->post(route('password.reset.force'), [
+            'password' => 'Str0ng!NewP@ssword',
+            'password_confirmation' => 'Str0ng!NewP@ssword',
+        ])
+        ->assertRedirect(route('dasbor'));
+});

--- a/tests/Feature/StrongPasswordRuleTest.php
+++ b/tests/Feature/StrongPasswordRuleTest.php
@@ -223,4 +223,85 @@ class StrongPasswordRuleTest extends TestCase
         // New password should pass
         $this->assertTrue($rule->passes('password', 'NewSecurePass456!'));
     }
+
+    /**
+     * Test password history check with $user parameter (unauthenticated).
+     */
+    public function test_password_history_with_user_parameter(): void
+    {
+        $user = User::factory()->create();
+        $user->passwordHistory()->create([
+            'password' => \Illuminate\Support\Facades\Hash::make('OldSecurePass123!'),
+            'reason' => 'password_change',
+        ]);
+
+        // Not logged in — history check should use the $user parameter
+        $rule = new StrongPassword(checkHibp: false, user: $user);
+
+        $this->assertFalse($rule->passes('password', 'OldSecurePass123!'));
+        $this->assertTrue($rule->passes('password', 'NewSecurePass456!'));
+    }
+
+    /**
+     * Test password history check skips when no user context.
+     */
+    public function test_password_history_skips_when_no_user(): void
+    {
+        // No user passed, not logged in — history check should allow
+        $rule = new StrongPassword(checkHibp: false);
+
+        $this->assertTrue($rule->passes('password', 'AnyPassword123!'));
+    }
+
+    /**
+     * Test password check against configured history count (10).
+     */
+    public function test_password_history_checks_against_all_entries(): void
+    {
+        $user = User::factory()->create();
+        $historyCount = config('password.history_count', 10);
+
+        for ($i = 0; $i < $historyCount; $i++) {
+            $user->passwordHistory()->create([
+                'password' => \Illuminate\Support\Facades\Hash::make("UsedP@ssw0rd{$i}!"),
+                'reason' => 'password_change',
+            ]);
+        }
+
+        $rule = new StrongPassword(checkHibp: false, user: $user);
+
+        for ($i = 0; $i < $historyCount; $i++) {
+            $this->assertFalse(
+                $rule->passes('password', "UsedP@ssw0rd{$i}!"),
+                "Password 'UsedP@ssw0rd{$i}!' should be rejected"
+            );
+        }
+
+        $this->assertTrue($rule->passes('password', 'BrandN3wP@ss!'));
+    }
+
+    /**
+     * Test history check respects custom historySize parameter.
+     */
+    public function test_password_history_respects_custom_size(): void
+    {
+        $user = User::factory()->create();
+
+        // Create 10 history entries
+        for ($i = 0; $i < 10; $i++) {
+            $user->passwordHistory()->create([
+                'password' => \Illuminate\Support\Facades\Hash::make("UsedP@ssw0rd{$i}!"),
+                'reason' => 'password_change',
+            ]);
+        }
+
+        // Only check last 3
+        $rule = new StrongPassword(checkHibp: false, historySize: 3, user: $user);
+
+        // The 10th entry (most recent, index 9) should be blocked
+        $this->assertFalse($rule->passes('password', 'UsedP@ssw0rd9!'));
+
+        // The 1st entry (oldest, index 0) should be allowed (outside the 3)
+        $this->assertTrue($rule->passes('password', 'UsedP@ssw0rd0!'));
+    }
 }

--- a/tests/Feature/StrongPasswordRuleTest.php
+++ b/tests/Feature/StrongPasswordRuleTest.php
@@ -147,14 +147,24 @@ class StrongPasswordRuleTest extends TestCase
     public function test_error_messages(): void
     {
         $rule = new StrongPassword();
-        $messages = $rule->message();
 
-        $this->assertArrayHasKey('length', $messages);
-        $this->assertArrayHasKey('complexity', $messages);
-        $this->assertArrayHasKey('hibp', $messages);
-        $this->assertArrayHasKey('history', $messages);
-        $this->assertArrayHasKey('weak_pattern', $messages);
-        $this->assertArrayHasKey('common', $messages);
+        $this->assertFalse($rule->passes('password', 'short1A@'));
+        $this->assertStringContainsString('minimal 12', $rule->message());
+
+        $this->assertFalse($rule->passes('password', 'nouppercase1!@#'));
+        $this->assertStringContainsString('huruf kapital', $rule->message());
+
+        $this->assertFalse($rule->passes('password', 'NOLOWERCASE1!@#'));
+        $this->assertStringContainsString('huruf kecil', $rule->message());
+
+        $this->assertFalse($rule->passes('password', 'NoNumber!@#abc'));
+        $this->assertStringContainsString('angka', $rule->message());
+
+        $this->assertFalse($rule->passes('password', 'NoSpecialChar1abc'));
+        $this->assertStringContainsString('karakter spesial', $rule->message());
+
+        $generic = (new StrongPassword())->message();
+        $this->assertIsString($generic);
     }
 
     /**


### PR DESCRIPTION
# Pull Request: Feature Password History (10 Riwayat Kata Sandi)

## Description

Menerapkan mekanisme **Password History** yang menyimpan 10 riwayat kata sandi terakhir untuk setiap akun dan mencegah penggunaan kembali kata sandi yang pernah digunakan sebelumnya. Validasi diterapkan di seluruh mekanisme perubahan dan reset kata sandi melalui **FormRequest** dan penyimpanan riwayat dilakukan otomatis melalui **UserObserver**.

### Changes made:

1. **New**: `app/Observers/UserObserver.php` — Observer pada model User yang otomatis menyimpan hash password lama ke tabel `password_histories` dan melakukan pruning (hapus riwayat > 10) dalam transaksi database
2. **Modified**: `app/Rules/StrongPassword.php` — Menambah parameter `$user` untuk pengecekan riwayat password pada konteks **unauthenticated** (reset password via email); default `historySize` berubah jadi 10; tracking `$failedRule` agar `message()` hanya mengembalikan 1 pesan relevan (bukan semua 6)
3. **Modified**: `app/Http/Requests/ChangePasswordRequest.php` — Override `failedValidation()` untuk menampilkan flash error notification saat validasi gagal
4. **Modified**: `app/Http/Requests/ResetPasswordRequest.php` — Mencari user by email dan meneruskan ke `StrongPassword(user: $user)` agar validasi riwayat tetap berjalan pada reset password via email; tambah flash error notification saat validasi gagal
5. **Modified**: `app/Http/Controllers/Auth/ResetPasswordController.php` — Menghapus manual `PasswordHistory::create()`, diganti dengan `$user->passwordHistoryReason` yang diproses oleh observer
6. **Modified**: `app/Http/Controllers/ForcePasswordResetController.php` — Sama, menghapus manual history creation, diganti dengan observer pattern
7. **Modified**: `app/Models/User.php` — Menambah properti `$passwordHistoryReason` dan `$oldPasswordHash`; `setPasswordWithHistory()` didelegasikan ke observer
8. **Modified**: `app/Providers/AppServiceProvider.php` — Mendaftarkan `UserObserver` pada model User
9. **Modified**: `config/password.php` — `history_count` dari 5 menjadi 10
10. **Fixed**: `tests/Feature/LoginControllerTest.php` — Captcha test menggunakan user agent konsisten (`'Symfony'`) dan `Setting::updateOrCreate()` untuk mengaktifkan captcha
11. **Fixed**: `tests/Feature/OtpLoginControllerTest.php` — Sama, captcha test diperbaiki
12. **New**: `tests/Feature/PasswordHistoryTest.php` — 8 test untuk UserObserver (simpan hash, custom reason, skip new user, pruning, dll)
13. **New**: `tests/Feature/PasswordResetFlowTest.php` — 6 test untuk ForcePasswordResetController (form, redirect, sukses, history, reject reuse)
14. **Modified**: `tests/Feature/StrongPasswordRuleTest.php` — 4 test baru untuk `$user` parameter, batas 10 entry, custom historySize; test `error_messages` diadaptasi ke single-message pattern

### Reason for change:

- **Keamanan**: Mencegah pengguna menggunakan kembali kata sandi lama yang mungkin telah terkompromi
- **Standar**: Menyesuaikan dengan praktik keamanan aplikasi modern (NIST SP 800-63B merekomendasikan pengecekan riwayat password)
- **Sentralisasi**: Memindahkan logika pencatatan riwayat dari tiap controller ke observer, menjamin konsistensi di seluruh flow perubahan password

### Impact of change:

- **Keamanan**: Riwayat 10 password terakhir dicek di semua mekanisme perubahan/reset password
- **Konsistensi**: Observer menjamin setiap perubahan password terekam, tanpa ada celah controller yang terlewat
- **Maintainability**: Logika pruning dan penyimpanan terpusat di observer, bukan tersebar di controller

## Related Issue

- Closes #1095

https://github.com/OpenSID/OpenKab/issues/1095

## Steps to Reproduce

### Sebelum:
1. User mengganti password berulang kali dengan password yang sama
2. Password lama tidak dicek, user bisa menggunakan password yang sama terus-menerus
3. Riwayat hanya menyimpan 5 password terakhir
4. Validasi riwayat hanya berjalan saat user sedang login (tidak pada reset password via email)

### Sesudah:
1. User mengganti password → hash lama tersimpan otomatis di `password_histories` via observer
2. User mengganti password dengan salah satu dari 10 terakhir → ditolak dengan pesan error
3. Riwayat > 10 otomatis dipangkas oleh observer
4. Validasi riwayat juga berjalan pada reset password via email (unauthenticated context)

## Checklist

- [x] I have complied with script writing rules
- [x] I have followed pull request review process
- [x] I have created unit/integration test to verify the fix
- [x] Manual testing has been done in development environment
- [x] No console errors or warnings
- [x] Code has been reviewed by team

## Technical Details

### Arsitektur Observer

```
User (model)
  │
  ├─ $user->password = '...'
  ├─ $user->save()
  │
  └─ UserObserver::saving()
       └─ jika password dirty → simpan hash lama ke $user->oldPasswordHash
     UserObserver::saved()
       └─ jika oldPasswordHash isset →
            ├─ INSERT ke password_histories (hash lama + reason)
            ├─ DELETE history > 10 (dalam DB::transaction)
            └─ $user->oldPasswordHash = null
```

### Validasi FormRequest

Setiap form request yang menerima input password baru menginstansiasi `StrongPassword`:
- `ChangePasswordRequest` → user dari `auth()->user()`
- `ResetPasswordRequest` → user ditemukan dari email, diteruskan via `StrongPassword(user: $user)`
- `ForcePasswordResetRequest` → user dari `auth()->user()`

`StrongPassword::isNotInHistory()` menggunakan prioritas: `$this->user` > `auth()->user()` > skip.

### Pesan Error Spesifik

`StrongPassword::passes()` mencatat jenis kegagalan via `$this->failedRule`:
- `'length'` → "Password harus memiliki minimal N karakter."
- `'complexity'` → "Password harus mengandung huruf kapital, huruf kecil, angka, dan karakter spesial."
- `'history'` → "Password ini telah digunakan sebelumnya."
- `'hibp'` → "Password ini telah bocor di HIBP."
- `'weak_pattern'` → "Password terlalu lemah atau mudah ditebak."
- `'common'` → "Password ini terlalu umum."

`message()` hanya mengembalikan **1 pesan** sesuai jenis kegagalan terakhir, bukan seluruh array. `failedValidation()` di FormRequest me-flash pesan ini ke `session()->flash('error', ...)` sehingga `flash_message.blade.php` menampilkan notifikasi merah yang relevan.

### Configuration changes

- `config/password.php` — `'history_count' => 10`

### Dependencies added

Tidak ada dependensi baru

## Testing

### Manual Testing
- [x] Ganti password via profil dengan password yang sama → ditolak
- [x] Ganti password via force reset → history tercatat
- [x] Reset password via email → validasi riwayat tetap berjalan
- [x] Isi riwayat > 10 → otomatis dipangkas

### Automated Testing
- [x] **PasswordHistoryTest** (8 tests) — Observer, pruning, user context
- [x] **PasswordResetFlowTest** (6 tests) — ForcePasswordResetController end-to-end
- [x] **StrongPasswordRuleTest** (17 tests) — 4 baru + 13 existing tetap pass
- [x] **LoginControllerTest** (15 of 16) — Captcha test diperbaiki, 1 skipped pre-existing
- [x] **OtpLoginControllerTest** (19 of 22) — Captcha test diperbaiki, 3 skipped pre-existing
- [x] **TwoFactorControllerTest**, **BruteForceSimulationTest**, **IdorPreventionTest** — Semua tetap pass
- [x] Total: **109 passed, 0 failures, 4 skipped**

## Screenshots / Video

https://github.com/user-attachments/assets/1e45db67-e1f7-4d6c-8a59-21f544917c5c


Tidak ada perubahan UI

## Breaking Changes

Tidak ada. Semua method existing (`setPasswordWithHistory`, `forcePasswordReset`) tetap berfungsi. Perubahan hanya pada internal storage mechanism (dari manual ke observer).

## Migration Guide

Tidak diperlukan. Migration `2026_03_11_000001_create_password_histories_table.php` sudah ada di codebase.

---
