### PR TITLE
Sesuaikan param kode_desa → config_desa Sandang

### DIFF
--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -5,7 +5,8 @@ Di rilis ini, versi 2608.0.0 berisi penambahan dan perbaikan yang diminta penggu
 #### Perbaikan BUG
 
 1. [#1105](https://github.com/OpenSID/OpenKab/issues/1105) Perbaikan filter kecamatan tampil tanpa memilih kabupaten terlebih dahulu.
- 
+2. [#1108](https://github.com/OpenSID/OpenKab/issues/1108) Perbaiki filter tahun dan desa masih ada yang kurang di data sandang.
+
 
 #### Perubahan Teknis
 

--- a/resources/views/dtks/sandang/index.blade.php
+++ b/resources/views/dtks/sandang/index.blade.php
@@ -75,7 +75,7 @@
         var url = new URL("{{ config('app.databaseGabunganUrl').'/api/v1/data-presisi/sandang/rtm' }}");
         url.searchParams.set("kode_kabupaten", "{{ session('kabupaten.kode_kabupaten') ?? '' }}");
         url.searchParams.set("kode_kecamatan", "{{ session('kecamatan.kode_kecamatan') ?? '' }}");
-        url.searchParams.set("kode_desa", "{{ session('desa.id') ?? '' }}");        
+        url.searchParams.set("config_desa", "{{ session('desa.id') ?? '' }}");        
 
         var dtks = $('#table-dtks').DataTable({
             processing: true,
@@ -95,7 +95,7 @@
                         "page[size]": row.length,
                         "page[number]": (row.start / row.length) + 1,
                         "filter[search]": row.search.value,
-                        "filter[tahun]": $('#filter-tahun').val(),                      
+                        "filter[tahun]": $('#filter-tahun').val()
                     };
                 },
                 dataSrc: function(json) {                   

--- a/resources/views/dtks/sandang/index.blade.php
+++ b/resources/views/dtks/sandang/index.blade.php
@@ -71,11 +71,11 @@
         const kodeKabupaten = "{{ $kodeKabupaten }}";
         const kodeKecamatan = "{{ $kodeKecamatan }}";
         const configDesa = "{{ $configDesa }}";
-
+        
         var url = new URL("{{ config('app.databaseGabunganUrl').'/api/v1/data-presisi/sandang/rtm' }}");
         url.searchParams.set("kode_kabupaten", "{{ session('kabupaten.kode_kabupaten') ?? '' }}");
         url.searchParams.set("kode_kecamatan", "{{ session('kecamatan.kode_kecamatan') ?? '' }}");
-        url.searchParams.set("config_desa", "{{ session('desa.id') ?? '' }}");        
+        url.searchParams.set("config_desa", configDesa);        
 
         var dtks = $('#table-dtks').DataTable({
             processing: true,


### PR DESCRIPTION
issue terkait https://github.com/OpenSID/OpenKab/issues/1108
Di API-Database-Gabungan, filter wilayah desa diproses melalui dua mekanisme:

config_desa (integer ID dari tabel config) — parameter utama yang benar, langsung digunakan oleh macro filterDesa() untuk query config_id.
kode_desa (string kode wilayah, mis. 50.01.01.001) — parameter lama/fallback yang masih didukung oleh macro filterWilayah() via lookup Config::where('kode_desa', ...) → id.
File dtks/sandang/index.blade.php sudah benar menggunakan config_desa dengan nilai session('desa.id'). Temuan riset menunjukkan masih banyak view dan service di OpenKab yang mengirim kode_desa dengan nilai session('desa.id') (yang merupakan integer ID, bukan kode string) 