### PR TITLE
Fix: Perbaikan error statistik pada halaman Data Pokok Pendidikan dan Ketenagakerjaan

### DIFF
--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -5,10 +5,10 @@ Di rilis ini, versi 2608.0.1 berisi penambahan dan perbaikan yang diminta penggu
 #### Perbaikan BUG
 
 1. [#1105](https://github.com/OpenSID/OpenKab/issues/1105) Perbaikan filter kecamatan tampil tanpa memilih kabupaten terlebih dahulu.
-2. [#1108](https://github.com/OpenSID/OpenKab/issues/1108) Perbaiki filter tahun dan desa masih ada yang kurang di data sandang.
-3. [#1111](https://github.com/OpenSID/OpenKab/issues/1111) Perbaiki style pada halaman slide tertutupi card icon penduduk.
+2. [#1108](https://github.com/OpenSID/OpenKab/issues/1108) Perbaikan filter tahun dan desa masih ada yang kurang di data sandang.
+3. [#1111](https://github.com/OpenSID/OpenKab/issues/1111) Perbaikan style pada halaman slide tertutupi card icon penduduk.
 4. [#1262](https://github.com/OpenSID/OpenKab/issues/1262) Perbaikan grafik tidak tampil pada Profile Kependudukan - Kesehatan.
- 
+5. [#1260](https://github.com/OpenSID/OpenKab/issues/1260) Perbaikan Error 500 gagal ambil data statistik partisipasi sekolah dan ijazah tertinggi.
 
 
 #### Perubahan Teknis

--- a/resources/views/data_pokok/ketenagakerjaan/chart.blade.php
+++ b/resources/views/data_pokok/ketenagakerjaan/chart.blade.php
@@ -12,7 +12,7 @@
             'kode_kecamatan': filters ? filters.kodeKecamatan : '',
             'config_desa': filters ? filters.configDesa : '',
         };
-        apiProxyGet('ketenagakerjaan/statistik', params, function(json) {
+        apiProxyGet('data-presisi/ketenagakerjaan/statistik', params, function(json) {
             var data = [];
             if (json.data && json.data.length > 0) {
                 json.data.forEach(function(item) {

--- a/resources/views/data_pokok/pendidikan/chart.blade.php
+++ b/resources/views/data_pokok/pendidikan/chart.blade.php
@@ -12,7 +12,7 @@
             'kode_kecamatan': filters ? filters.kodeKecamatan : '',
             'config_desa': filters ? filters.configDesa : '',
         };
-        apiProxyGet('pendidikan/statistik', params, function(json) {
+        apiProxyGet('data-presisi/pendidikan/statistik', params, function(json) {
             var data = [];
             if (json.data && json.data.length > 0) {
                 json.data.forEach(function(item) {


### PR DESCRIPTION
issue # https://github.com/OpenSID/OpenKab/issues/1260
penyesuaian di API Gabungan https://github.com/OpenSID/API-Database-Gabungan/pull/458

## 🎯 Deskripsi

Pull request ini memperbaiki *bug* pada halaman **Data Pokok Pendidikan** (`/data-pokok/pendidikan`) dan **Data Pokok Ketenagakerjaan** (`/data-pokok/ketenagakerjaan`) di mana grafik statistik gagal dimuat dan memunculkan *pop-up* error `Error! Gagal mengambil data dari API` (respons HTTP 500 dari API Proxy).

Penyebab utamanya adalah kesalahan arah *endpoint* pada pemanggilan `apiProxyGet()` di view:

1. View memanggil `pendidikan/statistik` dan `ketenagakerjaan/statistik`, padahal route yang terdaftar di API Database Gabungan berada di bawah prefix `data-presisi`, yaitu `data-presisi/pendidikan/statistik` dan `data-presisi/ketenagakerjaan/statistik`. Akibatnya upstream mengembalikan `404 Resource not found`, exception ditangkap oleh `ApiProxyService::callApi()`, dan proxy membalas `{"error": "Gagal mengambil data dari API"}` dengan status 500.
2. Setelah arah *endpoint* dikoreksi, endpoint statistik data presisi pendidikan ternyata hanya mendukung 4 kategori (`pendidikan_dalam_kk`, `pendidikan_sedang_ditempuh`, `keikutsertaan_kip`, `jenis_pendidikan_kesetaraan_yg_diikuti`), sedangkan halaman pendidikan membutuhkan kategori `partisipasi_sekolah` (Statistik Partisipasi Sekolah) dan `ijazah_tertinggi` (Statistik Ijazah Tertinggi) yang bersumber dari data DTKS anggota (`dtks_anggota`).

Dengan menambahkan dukungan kedua kategori DTKS tersebut pada repository statistik pendidikan di sisi upstream, kedua grafik kini menampilkan data yang benar dan konsisten dengan kolom-kolom pada tabel Data Pendidikan.

---

## 🛠️ Perubahan yang Dilakukan

### 1. `resources/views/data_pokok/pendidikan/chart.blade.php` (OpenKab)

**Fix — Koreksi endpoint statistik pada grafik Pendidikan:**

- Mengubah pemanggilan `apiProxyGet('pendidikan/statistik', ...)` menjadi `apiProxyGet('data-presisi/pendidikan/statistik', ...)` agar sesuai dengan route yang terdaftar di API Database Gabungan.

```diff
- apiProxyGet('pendidikan/statistik', params, function(json) {
+ apiProxyGet('data-presisi/pendidikan/statistik', params, function(json) {
```

---

### 2. `resources/views/data_pokok/ketenagakerjaan/chart.blade.php` (OpenKab)

**Fix — Koreksi endpoint statistik pada grafik Ketenagakerjaan:**

- Mengubah pemanggilan `apiProxyGet('ketenagakerjaan/statistik', ...)` menjadi `apiProxyGet('data-presisi/ketenagakerjaan/statistik', ...)` agar sesuai dengan route yang terdaftar di API Database Gabungan.

```diff
- apiProxyGet('ketenagakerjaan/statistik', params, function(json) {
+ apiProxyGet('data-presisi/ketenagakerjaan/statistik', params, function(json) {
```

---

### 3. `app/Repositories/DataPresisiPendidikanRepository.php` (API-Database-Gabungan)

**Add — Dukungan kategori statistik DTKS `partisipasi_sekolah` dan `ijazah_tertinggi`:**

- Mempertahankan 4 kategori lama (`pendidikan_dalam_kk`, `pendidikan_sedang_ditempuh`, `keikutsertaan_kip`, `jenis_pendidikan_kesetaraan_yg_diikuti`) tanpa perubahan perilaku.
- Menambahkan method `listStatistikDtks()` yang menghitung statistik dari tabel `dtks_anggota` menggunakan `leftJoin` terhadap tabel referensi:
  - `partisipasi_sekolah` → `tweb_penduduk_pendidikan` (`dtks_anggota.kd_partisipasi_sekolah`)
  - `ijazah_tertinggi` → `tweb_penduduk_pendidikan_kk` (`dtks_anggota.kd_ijazah_tertinggi`)
- Menggunakan `filterWilayah('dtks_anggota')` agar filter wilayah (`kode_kabupaten`, `kode_kecamatan`, `config_desa`) tetap berlaku, dan memetakan nilai `null`/kosong menjadi `BELUM MENGISI` sesuai konvensi statistik yang sudah ada.
- Bentuk *Collection* yang dikembalikan identik dengan kategori lama sehingga logika `JUMLAH`/`TOTAL` dan *sorting* pada `DataPresisiPendidikanController::statistik()` tetap berjalan tanpa perubahan.
- Parameter `tahun` diabaikan untuk kategori DTKS karena data DTKS tidak terikat pada tahun data presisi.

```diff
 public function listStatistik(string $kategori, int|string $tahun): Collection
 {
+    if (in_array($kategori, ['partisipasi_sekolah', 'ijazah_tertinggi'], true)) {
+        return $this->listStatistikDtks($kategori);
+    }
+
     $allowedColumns = [
         'pendidikan_dalam_kk',
         'pendidikan_sedang_ditempuh',
         'keikutsertaan_kip',
         'jenis_pendidikan_kesetaraan_yg_diikuti',
     ];
 
     if (! in_array($kategori, $allowedColumns, true)) {
         return collect();
     }
 
     $tahun = (int) $tahun;
 
     return DataPresisiPendidikan::whereRelation('tahun', static fn ($q) => $q->whereTahun($tahun))->selectRaw($kategori.' as nilai, count(*) as jumlah')->filterWilayah()->groupBy($kategori)->get()->groupBy(
         static function ($item) {
             return ($item->nilai === null || $item->nilai === '') ? 'BELUM MENGISI' : $item->nilai;
         }
     );
 }
+
+/**
+ * Statistik kategori pendidikan dari data DTKS anggota.
+ * Kategori ini tidak terkait tahun data presisi, sehingga parameter tahun diabaikan.
+ */
+private function listStatistikDtks(string $kategori): Collection
+{
+    $references = [
+        'partisipasi_sekolah' => ['tweb_penduduk_pendidikan', 'kd_partisipasi_sekolah'],
+        'ijazah_tertinggi' => ['tweb_penduduk_pendidikan_kk', 'kd_ijazah_tertinggi'],
+    ];
+
+    [$referenceTable, $foreignKey] = $references[$kategori];
+
+    return DtksAnggota::leftJoin($referenceTable, $referenceTable.'.id', '=', 'dtks_anggota.'.$foreignKey)
+        ->selectRaw($referenceTable.'.nama as nilai, count(*) as jumlah')
+        ->filterWilayah('dtks_anggota')
+        ->groupBy($referenceTable.'.nama')
+        ->get()
+        ->groupBy(
+            static function ($item) {
+                return ($item->nilai === null || $item->nilai === '') ? 'BELUM MENGISI' : $item->nilai;
+            }
+        );
+}
```

---

### 4. `tests/Feature/DataPresisiPendidikanControllerApiTest.php` (API-Database-Gabungan)

**Test — Penambahan test untuk kategori statistik baru:**

- Menambahkan `test_get_statistik_partisipasi_sekolah()` yang memverifikasi endpoint `/api/v1/data-presisi/pendidikan/statistik?kategori=partisipasi_sekolah&kode_kabupaten=5102` mengembalikan status `200` dengan struktur `data.*.attributes.{nilai, jumlah}`.
- Menambahkan `test_get_statistik_ijazah_tertinggi()` dengan verifikasi yang sama untuk kategori `ijazah_tertinggi`.
- Kedua test menggunakan pola `markTestSkipped` bila data `DtksAnggota` tidak tersedia, mengikuti konvensi test statistik yang sudah ada.

---

## ✅ Test Cases yang Diimplementasikan

- [x] Grafik **Statistik Partisipasi Sekolah** dan **Statistik Ijazah Tertinggi** pada halaman `/data-pokok/pendidikan` termuat tanpa *pop-up* error dan menampilkan data.
- [x] Grafik statistik pada halaman `/data-pokok/ketenagakerjaan` termuat normal.
- [x] Endpoint API proxy `api-proxy/get?endpoint=data-presisi/pendidikan/statistik&kategori=partisipasi_sekolah&kode_kabupaten=5102` mengembalikan status `200` dengan data (`nilai`, `jumlah`) yang valid.
- [x] Endpoint API proxy `api-proxy/get?endpoint=data-presisi/pendidikan/statistik&kategori=ijazah_tertinggi&kode_kabupaten=5102` mengembalikan status `200` dengan data (`nilai`, `jumlah`) yang valid.
- [x] Empat kategori statistik lama (`pendidikan_dalam_kk`, `pendidikan_sedang_ditempuh`, `keikutsertaan_kip`, `jenis_pendidikan_kesetaraan_yg_diikuti`) tetap berperilaku sama (tanpa regresi).
- [x] Seluruh test pada `DataPresisiPendidikanControllerApiTest` lulus (18 passed) termasuk 2 test baru.

---

## 📸 Cara Menjalankan Uji Coba Manual

1. Jalankan aplikasi OpenKab dan pastikan API Database Gabungan berjalan serta token API (`database_gabungan_api_key`) sudah terisi.
2. Login sebagai pengguna dengan hak akses Data Pokok Pendidikan.
3. Buka menu **Data Pokok > Pendidikan** atau akses URL `/data-pokok/pendidikan`.
   - ✅ **Seharusnya:** Grafik **Statistik Ijazah Tertinggi** (bar) dan **Statistik Partisipasi Sekolah** (donut) terisi data, tidak ada *pop-up* `Error! Gagal mengambil data dari API`.
4. Buka menu **Data Pokok > Ketenagakerjaan** atau akses URL `/data-pokok/ketenagakerjaan`.
   - ✅ **Seharusnya:** Grafik statistik terisi data tanpa error.
5. (Opsional) Dengan sesi login aktif, buka URL berikut pada browser:
   - `http://127.0.0.1:8000/api-proxy/get?endpoint=data-presisi/pendidikan/statistik&kategori=partisipasi_sekolah&kode_kabupaten=5102`
   - `http://127.0.0.1:8000/api-proxy/get?endpoint=data-presisi/pendidikan/statistik&kategori=ijazah_tertinggi&kode_kabupaten=5102`
   - ✅ **Seharusnya:** Respons JSON `200` berisi `data` dengan atribut `nilai` dan `jumlah`.

---

## 🤖 Cara Menjalankan Uji Coba Otomatis (Automated Test)

Jalankan test pada repository **API-Database-Gabungan** (provider):

```bash
php artisan test tests/Feature/DataPresisiPendidikanControllerApiTest.php
```

Dan test pada repository **OpenKab** (consumer) untuk memastikan API Proxy tidak terpengaruh:

```bash
php artisan test tests/Feature/Http/Controllers/ApiProxyControllerTest.php
```

---

## 📸 Screenshot atau Video
<img width="1149" height="717" alt="image" src="https://github.com/user-attachments/assets/b0bb895e-3815-435a-b923-5b3a6de42ba3" />

---

## ⚠️ Catatan Penting

> Perubahan ini melibatkan dua repository: **OpenKab** (perbaikan arah endpoint pada view) dan **API-Database-Gabungan** (dukungan kategori statistik DTKS). Keduanya harus di-deploy bersama agar halaman berfungsi penuh.
>
> Kategori statistik DTKS (`partisipasi_sekolah` dan `ijazah_tertinggi`) tidak terikat pada parameter `tahun` data presisi, sehingga filter tahun tidak memengaruhi hasil kedua grafik tersebut.
>
> Jika setelah deploy hasil statistik masih tampak kosong, bersihkan cache upstream karena respons lama (saat kategori belum didukung) tersimpan pada cache key `cache:pendidikan-*`:
>
> ```bash
> php artisan cache:clear
> ```