### PR TITLE
Perbaikan data desa tidak tampil / tidak sesuai filter saat membuka halaman Desa dari Dasbor

### DIFF
--- a/app/Http/Controllers/DesaController.php
+++ b/app/Http/Controllers/DesaController.php
@@ -14,6 +14,10 @@ class DesaController extends Controller
             'kode_kecamatan' => null,
         ]);
 
+        $filters = collect($filters)->map(function ($value) {
+            return in_array($value, ['null', 'undefined'], true) ? null : $value;
+        })->all();
+
         return view('desa.index', compact('filters'));
     }
 

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -9,7 +9,7 @@ Di rilis ini, versi 2608.0.1 berisi penambahan dan perbaikan yang diminta penggu
 3. [#1111](https://github.com/OpenSID/OpenKab/issues/1111) Perbaikan style pada halaman slide tertutupi card icon penduduk.
 4. [#1262](https://github.com/OpenSID/OpenKab/issues/1262) Perbaikan grafik tidak tampil pada Profile Kependudukan - Kesehatan.
 5. [#1260](https://github.com/OpenSID/OpenKab/issues/1260) Perbaikan Error 500 gagal ambil data statistik partisipasi sekolah dan ijazah tertinggi.
-
+6. [#1265](https://github.com/OpenSID/OpenKab/issues/1265) perbaikan data desa tidak tampil di OpenKab.
 
 #### Perubahan Teknis
 

--- a/resources/views/components/wilayah_filter_js.blade.php
+++ b/resources/views/components/wilayah_filter_js.blade.php
@@ -7,6 +7,10 @@
             };
             const identitasOpenkab = $(`meta[name="${AJAX_PARAMS_CONFIG.metaTagName}"]`).attr('content') || '';
             let isAutoLoad = false;
+            let urlFilterRestoring = false;
+            const queryKodeKabupaten = new URLSearchParams(window.location.search).get('filter[kode_kabupaten]');
+            const queryKodeKecamatan = new URLSearchParams(window.location.search).get('filter[kode_kecamatan]');
+            const queryKodeDesa = new URLSearchParams(window.location.search).get('filter[kode_desa]');
 
             let urlKabupaten =
                 "{{ config('app.databaseGabunganUrl') . '/api/v1/statistik-web/get-list-kabupaten' }}?" +
@@ -20,7 +24,6 @@
                 var optionEmpty = new Option("", "");
                 $("#filter_kabupaten").append(optionEmpty);
 
-                const queryKodeKabupaten = new URLSearchParams(window.location.search).get('filter[kode_kabupaten]');
                 const filterValue = queryKodeKabupaten || identitasOpenkab;
 
                 for (var i = 0; i < data.length; i++) {
@@ -30,6 +33,7 @@
 
                     if (data[i].kode_kabupaten === filterValue) {
                         isAutoLoad = true;
+                        urlFilterRestoring = true;
                         $("#filter_kabupaten").val(filterValue).trigger('change');
                     }
                 }
@@ -75,8 +79,18 @@
                             $("#filter_kecamatan").append(newOption);
                         }
                         $('#filter_kecamatan').prop('disabled', false);
+                        if (urlFilterRestoring && queryKodeKecamatan) {
+                            $('#filter_kecamatan').val(queryKodeKecamatan);
+                            if ($('#filter_kecamatan').val() === queryKodeKecamatan) {
+                                $('#filter_kecamatan').trigger('change');
+                            } else {
+                                urlFilterRestoring = false;
+                            }
+                        } else {
+                            urlFilterRestoring = false;
+                        }
                         if (isAutoLoad) {
-                            $('#bt_filter').trigger('click');
+                            $('#bt_filter, #filter').trigger('click');
                             isAutoLoad = false;
                         }
                     })
@@ -104,6 +118,11 @@
                             $("#filter_desa").append(newOption);
                         }
                         $('#filter_desa').prop('disabled', false);
+                        if (urlFilterRestoring && queryKodeDesa) {
+                            $('#filter_desa').val(queryKodeDesa);
+                            $('#filter_desa').trigger('change');
+                        }
+                        urlFilterRestoring = false;
                     })
                 }
             })

--- a/resources/views/dasbor/summary.blade.php
+++ b/resources/views/dasbor/summary.blade.php
@@ -30,9 +30,9 @@
                         $(`.kategori-item .jumlah-${index}-elm`).closest('.item-box').find('a')
                             .data(
                                 'filter', {
-                                    'kode_kabupaten': kabupaten,
-                                    'kode_kecamatan': kecamatan,
-                                    'kode_desa': desa,
+                                    'kode_kabupaten': kabupaten || '',
+                                    'kode_kecamatan': kecamatan || '',
+                                    'kode_desa': desa || '',
                                     'nama_kabupaten': $('#filter_kabupaten').find(':selected')
                                         .text(),
                                     'nama_kecamatan': $('#filter_kecamatan').find(':selected')
@@ -47,12 +47,13 @@
                 event.preventDefault();
                 let url = $(this).data('url');
                 let _url = new URL(url);
-                _url.searchParams.set('filter[kode_kabupaten]', $(this).data('filter')['kode_kabupaten']);
-                _url.searchParams.set('filter[kode_kecamatan]', $(this).data('filter')['kode_kecamatan']);
-                _url.searchParams.set('filter[kode_desa]', $(this).data('filter')['kode_desa']);
-                _url.searchParams.set('filter[nama_kabupaten]', $(this).data('filter')['nama_kabupaten']);
-                _url.searchParams.set('filter[nama_kecamatan]', $(this).data('filter')['nama_kecamatan']);
-                _url.searchParams.set('filter[nama_desa]', $(this).data('filter')['nama_desa']);
+                let filter = $(this).data('filter');
+                ['kode_kabupaten', 'kode_kecamatan', 'kode_desa', 'nama_kabupaten', 'nama_kecamatan', 'nama_desa']
+                    .forEach(function(key) {
+                        if (filter[key]) {
+                            _url.searchParams.set('filter[' + key + ']', filter[key]);
+                        }
+                    });
                 window.location.href = _url.href;
             })
         })

--- a/resources/views/desa/index.blade.php
+++ b/resources/views/desa/index.blade.php
@@ -132,25 +132,30 @@
                 serverSide: true,
                 autoWidth: false,
                 ordering: true,
+                order: [
+                    [1, 'asc']
+                ],
                 searchPanes: {
                     viewTotal: false,
                     columns: [0]
                 },
                 ajax: {
                     url: urlPenduduk,
+                    headers: header,
                     method: 'get',
                     data: function(row) {
                         return {
                             "page[size]": row.length,
                             "page[number]": (row.start / row.length) + 1,
                             "filter[search]": row.search.value,
-                            "filter[kode_kabupaten]": $("#filter_kabupaten").val(),
-                            "filter[kode_kecamatan]": $("#filter_kecamatan").val(),
-                            "filter[kode_desa]": $("#filter_desa").val(),
-                            "sort": (row.order[0]?.dir === "asc" ? "" : "-") + row.columns[row
+                            "filter[kode_kabupaten]": $("#filter_kabupaten").val() || '',
+                            "filter[kode_kecamatan]": $("#filter_kecamatan").val() || '',
+                            "filter[kode_desa]": $("#filter_desa").val() || '',
+                            "sort": row.columns[row.order[0]?.column]?.name ?
+                                (row.order[0]?.dir === "asc" ? "" : "-") + row.columns[row
                                     .order[0]
                                     ?.column]
-                                ?.name
+                                ?.name : undefined
                         };
                     },
                     dataSrc: function(json) {
@@ -173,7 +178,7 @@
                         }
                     },
                     {
-                        targets: [0, 1, 2, 3],
+                        targets: 0,
                         orderable: false,
                         searchable: false,
                     },
@@ -210,8 +215,8 @@
             $(document).on('click', '#reset', function(e) {
                 e.preventDefault();
                 $('#filter_kabupaten').val('').change();
-                $('#filter_kabupaten').val('').change();
-                $('#filter_kabupaten').val('').change();
+                $('#filter_kecamatan').val('').change();
+                $('#filter_desa').val('').change();
 
                 pendudukDatatable.ajax.reload();
             });

--- a/tests/Feature/DesaControllerTest.php
+++ b/tests/Feature/DesaControllerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\BaseTestCase;
+
+class DesaControllerTest extends BaseTestCase
+{
+    use DatabaseTransactions;
+
+    #[Test]
+    public function it_returns_200_on_desa_index()
+    {
+        $response = $this->get(route('desa.index'));
+
+        $response->assertStatus(200);
+        $response->assertViewIs('desa.index');
+    }
+
+    #[Test]
+    public function it_normalizes_null_string_filter_values()
+    {
+        $response = $this->get(route('desa.index') . '?filter[kode_kabupaten]=5102&filter[kode_kecamatan]=&filter[kode_desa]=null&filter[nama_kabupaten]=Tabanan&filter[nama_kecamatan]=&filter[nama_desa]=');
+
+        $response->assertStatus(200);
+        $response->assertViewHas('filters', function ($filters) {
+            return $filters['kode_kabupaten'] === '5102'
+                && empty($filters['kode_kecamatan'])
+                && $filters['kode_desa'] === null;
+        });
+    }
+
+    #[Test]
+    public function it_does_not_render_option_with_null_string_value()
+    {
+        $response = $this->get(route('desa.index') . '?filter[kode_kabupaten]=5102&filter[kode_kecamatan]=&filter[kode_desa]=null&filter[nama_kabupaten]=Tabanan&filter[nama_kecamatan]=&filter[nama_desa]=');
+
+        $response->assertStatus(200);
+        $response->assertDontSee('value="null"');
+        $response->assertSee('Tabanan');
+    }
+}


### PR DESCRIPTION
issue # https://github.com/OpenSID/OpenKab/issues/1265

## 🎯 Deskripsi

Pull request ini memperbaiki *bug* pada alur navigasi dari **Dasbor** menuju halaman **Data Desa** (`/desa`), di mana daftar desa pada DataTable tidak menampilkan data yang sesuai dengan parameter filter yang dikirim (bahkan tabel bisa kosong sama sekali).

Terdapat tiga akar masalah yang diperbaiki:

1. **Parameter `filter[kode_desa]=null` terkirim sebagai string literal.** Handler klik "Selengkapnya" pada kartu dasbor memanggil `URLSearchParams.set()` untuk semua key filter termasuk yang kosong. Karena `set(name, null)` mengonversi `null` menjadi string `"null"`, URL yang dihasilkan berisi `filter[kode_desa]=null`. Controller kemudian merender `<option value="null">` pada select desa, dan request DataTable mengirim nilai `"null"` tersebut sehingga *exact match* filter desa di API gagal.

2. **DataTable halaman desa mengirim `sort=undefined`.** Konfigurasi tabel memakai `ordering: true` tanpa `order` awal, sehingga DataTables memakai *default* `[[0, 'asc']]` pada kolom No yang tidak memiliki `name`. Akibatnya parameter `sort` dihitung menjadi `"undefined"` pada setiap request, ditolak oleh API (spatie QueryBuilder `allowedSorts`) dengan status `400`, dan tabel tidak pernah menampilkan data.

3. **Filter kecamatan/desa dari URL hilang setelah halaman dimuat.** Script wilayah filter men-trigger ulang select kabupaten secara *asynchronous* saat memuat daftar kabupaten. Cascade `empty()` pada handler `change` menghapus opsi kecamatan/desa yang sudah dirender server dari parameter URL. Selain itu, `isAutoLoad` mengeklik `#bt_filter` yang tidak ada di halaman desa (tombol filternya bernama `#filter`), sehingga DataTable tidak pernah di-*redraw* dengan filter hasil *restore*.

---

## 🛠️ Perubahan yang Dilakukan

### 1. `resources/views/dasbor/summary.blade.php`

**Fix — Hanya mengirim parameter filter yang terisi saat klik "Selengkapnya":**

- Nilai `data('filter')` pada kartu dinormalisasi dengan `|| ''` agar tidak pernah bernilai `null`.
- Handler klik kartu kini hanya memanggil `searchParams.set()` untuk key yang tidak kosong, sehingga URL tidak lagi memuat `filter[kode_desa]=null`.

```diff
                             .data(
                                 'filter', {
-                                    'kode_kabupaten': kabupaten,
-                                    'kode_kecamatan': kecamatan,
-                                    'kode_desa': desa,
+                                    'kode_kabupaten': kabupaten || '',
+                                    'kode_kecamatan': kecamatan || '',
+                                    'kode_desa': desa || '',
```

```diff
-                _url.searchParams.set('filter[kode_kabupaten]', $(this).data('filter')['kode_kabupaten']);
-                _url.searchParams.set('filter[kode_kecamatan]', $(this).data('filter')['kode_kecamatan']);
-                _url.searchParams.set('filter[kode_desa]', $(this).data('filter')['kode_desa']);
-                _url.searchParams.set('filter[nama_kabupaten]', $(this).data('filter')['nama_kabupaten']);
-                _url.searchParams.set('filter[nama_kecamatan]', $(this).data('filter')['nama_kecamatan']);
-                _url.searchParams.set('filter[nama_desa]', $(this).data('filter')['nama_desa']);
+                let filter = $(this).data('filter');
+                ['kode_kabupaten', 'kode_kecamatan', 'kode_desa', 'nama_kabupaten', 'nama_kecamatan', 'nama_desa']
+                    .forEach(function(key) {
+                        if (filter[key]) {
+                            _url.searchParams.set('filter[' + key + ']', filter[key]);
+                        }
+                    });
```

---

### 2. `app/Http/Controllers/DesaController.php`

**Fix — Normalisasi nilai filter string `"null"`/`"undefined"` menjadi `null`:**

- Filter yang diterima dari query string dinormalisasi sehingga select tidak lagi merender option `value="null"` dan DataTable tidak mengirim nilai `"null"` sebagai filter.

```diff
         $filters = request('filter', [
             'kode_kabupaten' => null,
             'kode_desa' => null,
             'kode_kecamatan' => null,
         ]);
 
+        $filters = collect($filters)->map(function ($value) {
+            return in_array($value, ['null', 'undefined'], true) ? null : $value;
+        })->all();
+
         return view('desa.index', compact('filters'));
```

---

### 3. `resources/views/desa/index.blade.php`

**Fix — Konfigurasi DataTable halaman desa:**

- Menambahkan `order: [[1, 'asc']]` (urutkan berdasarkan nama desa) sehingga request pertama mengirim `sort=nama_desa` yang valid, bukan `sort=undefined`.
- Menambahkan `headers: header` (Bearer token API) agar konsisten dengan halaman lain (penduduk/keluarga).
- Normalisasi nilai select dengan `|| ''` agar tidak mengirim nilai `null`/`undefined`.
- Guard pada parameter `sort`: hanya dikirim jika kolom target memiliki `name` (selain itu di-*skip*).
- `columnDefs` `orderable: false` dipersempit hanya untuk kolom No (target `0`); kolom nama desa, nama kecamatan, dan jumlah penduduk tetap dapat diurutkan sesuai desain awal fitur sort.
- Tombol **reset** kini mengosongkan ketiga select (kabupaten, kecamatan, desa) — sebelumnya kabupaten dikosongkan tiga kali.

```diff
                 autoWidth: false,
                 ordering: true,
+                order: [
+                    [1, 'asc']
+                ],
```

```diff
                 ajax: {
                     url: urlPenduduk,
+                    headers: header,
                     method: 'get',
                     data: function(row) {
                         return {
                             "page[size]": row.length,
                             "page[number]": (row.start / row.length) + 1,
                             "filter[search]": row.search.value,
-                            "filter[kode_kabupaten]": $("#filter_kabupaten").val(),
-                            "filter[kode_kecamatan]": $("#filter_kecamatan").val(),
-                            "filter[kode_desa]": $("#filter_desa").val(),
-                            "sort": (row.order[0]?.dir === "asc" ? "" : "-") + row.columns[row
+                            "filter[kode_kabupaten]": $("#filter_kabupaten").val() || '',
+                            "filter[kode_kecamatan]": $("#filter_kecamatan").val() || '',
+                            "filter[kode_desa]": $("#filter_desa").val() || '',
+                            "sort": row.columns[row.order[0]?.column]?.name ?
+                                (row.order[0]?.dir === "asc" ? "" : "-") + row.columns[row
                                     .order[0]
                                     ?.column]
-                                ?.name
+                                ?.name : undefined
```

```diff
                     {
-                        targets: [0, 1, 2, 3],
+                        targets: 0,
                         orderable: false,
                         searchable: false,
                     },
```

```diff
             $(document).on('click', '#reset', function(e) {
                 e.preventDefault();
                 $('#filter_kabupaten').val('').change();
-                $('#filter_kabupaten').val('').change();
-                $('#filter_kabupaten').val('').change();
+                $('#filter_kecamatan').val('').change();
+                $('#filter_desa').val('').change();
 
                 pendudukDatatable.ajax.reload();
             });
```

---

### 4. `resources/views/components/wilayah_filter_js.blade.php`

**Fix — Restore filter dari URL dan redraw tabel setelah cascade selesai:**

- `queryKodeKabupaten`, `queryKodeKecamatan`, dan `queryKodeDesa` dibaca dari `window.location.search` di *scope* top-level handler (sebelumnya `queryKodeKabupaten` hanya tersedia di dalam callback kabupaten).
- Menambahkan flag `urlFilterRestoring` yang hanya aktif saat kabupaten di-*restore* dari URL, sehingga pemilihan kecamatan/desa dari URL tidak mengganggu alur normal.
- Setelah daftar kecamatan dimuat, select kecamatan dipilih sesuai `filter[kode_kecamatan]` dari URL lalu `trigger('change')`; pola yang sama diterapkan untuk desa (`filter[kode_desa]`).
- `isAutoLoad` kini mengeklik `#bt_filter, #filter` sekaligus — halaman desa yang memiliki tombol filter `#filter` ikut ter-*redraw* dengan nilai filter hasil *restore* (halaman lain yang hanya memiliki `#bt_filter` tetap berperilaku sama seperti sebelumnya).

```diff
             const identitasOpenkab = $(`meta[name="${AJAX_PARAMS_CONFIG.metaTagName}"]`).attr('content') || '';
             let isAutoLoad = false;
+            let urlFilterRestoring = false;
+            const queryKodeKabupaten = new URLSearchParams(window.location.search).get('filter[kode_kabupaten]');
+            const queryKodeKecamatan = new URLSearchParams(window.location.search).get('filter[kode_kecamatan]');
+            const queryKodeDesa = new URLSearchParams(window.location.search).get('filter[kode_desa]');
```

```diff
                     if (data[i].kode_kabupaten === filterValue) {
                         isAutoLoad = true;
+                        urlFilterRestoring = true;
                         $("#filter_kabupaten").val(filterValue).trigger('change');
                     }
```

```diff
                         $('#filter_kecamatan').prop('disabled', false);
+                        if (urlFilterRestoring && queryKodeKecamatan) {
+                            $('#filter_kecamatan').val(queryKodeKecamatan);
+                            if ($('#filter_kecamatan').val() === queryKodeKecamatan) {
+                                $('#filter_kecamatan').trigger('change');
+                            } else {
+                                urlFilterRestoring = false;
+                            }
+                        } else {
+                            urlFilterRestoring = false;
+                        }
                         if (isAutoLoad) {
-                            $('#bt_filter').trigger('click');
+                            $('#bt_filter, #filter').trigger('click');
                             isAutoLoad = false;
                         }
```

```diff
                         $('#filter_desa').prop('disabled', false);
+                        if (urlFilterRestoring && queryKodeDesa) {
+                            $('#filter_desa').val(queryKodeDesa);
+                            $('#filter_desa').trigger('change');
+                        }
+                        urlFilterRestoring = false;
```

---

### 5. `tests/Feature/DesaControllerTest.php`

**Test — Penambahan feature test untuk halaman Desa:**

- `it_returns_200_on_desa_index()` — memastikan halaman `/desa` dapat diakses dan merender view `desa.index`.
- `it_normalizes_null_string_filter_values()` — memastikan nilai filter `"null"` dari query string dinormalisasi menjadi `null` pada controller.
- `it_does_not_render_option_with_null_string_value()` — memastikan view tidak merender `<option value="null">` dan tetap menampilkan opsi kabupaten dari URL.

---

## ✅ Test Cases yang Diimplementasikan

- [x] Klik **Selengkapnya** pada kartu desa di dasbor menghasilkan URL `/desa` yang hanya berisi parameter filter terisi (tidak lagi `filter[kode_desa]=null`).
- [x] Buka `/desa` dengan `filter[kode_kabupaten]=5102` → tabel menampilkan seluruh desa pada kabupaten tersebut.
- [x] Buka `/desa` dengan `filter[kode_kecamatan]` dan/atau `filter[kode_desa]` → select filter ter-*restore* dari URL dan tabel menampilkan data yang sesuai.
- [x] Request pertama DataTable halaman desa mengirim `sort=nama_desa` (bukan `sort=undefined`) sehingga API membalas `200`, bukan `400`.
- [x] Sorting pada kolom nama desa, nama kecamatan, dan jumlah penduduk tetap berfungsi.
- [x] Tombol **reset** mengosongkan filter kabupaten, kecamatan, dan desa sekaligus.
- [x] Feature test `DesaControllerTest` dan `DasborControllerTest` lulus (6 passed, 13 assertions).

---

## 📸 Cara Menjalankan Uji Coba Manual

1. Login ke aplikasi OpenKab dan pastikan API Database Gabungan berjalan.
2. Buka halaman **Dasbor** (`/dasbor`), lalu pilih kabupaten (dan opsional kecamatan/desa) pada filter wilayah.
3. Klik **Selengkapnya** pada kartu **Desa**.
   - ✅ **Seharusnya:** URL berisi parameter filter yang terisi saja, contoh: `?filter[kode_kabupaten]=5102&filter[nama_kabupaten]=TABANAN`.
4. Di halaman `/desa`, periksa tabel **Data Desa**:
   - ✅ **Seharusnya:** DataTable menampilkan data sesuai parameter (desa pada kabupaten/kecamatan/desa yang dipilih), tidak kosong.
   - ✅ **Seharusnya:** Select filter kabupaten/kecamatan/desa menampilkan nilai yang sama dengan parameter URL.
   - ✅ **Seharusnya:** Klik header kolom nama desa/kecamatan/jumlah penduduk dapat mengurutkan data tanpa error.
5. Klik tombol filter (**search**) dan **reset** — pastikan tabel mengikuti perubahan filter dengan benar.

---

## 🤖 Cara Menjalankan Uji Coba Otomatis (Automated Test)

```bash
php artisan test tests/Feature/DesaControllerTest.php
php artisan test tests/Feature/DasborControllerTest.php
```

---

## 📸 Screenshot atau Video

https://github.com/user-attachments/assets/b3c219eb-690c-4d1e-aceb-297c9ba409ea


---

## ⚠️ Catatan Penting

> Perubahan pada PR ini seluruhnya berada di sisi *consumer* (**OpenKab**); tidak ada perubahan kontrak atau kode pada **API-Database-Gabungan**.
>
> Bug `sort=undefined` muncul sejak fitur sort pada tabel desa ditambahkan (`ordering: true` tanpa `order` awal). Karena seluruh kolom awalnya dibuat *non-orderable*, DataTables tetap mengirim urutan default kolom No yang tidak memiliki `name`, dan request pertama selalu ditolak API dengan `400`.