### PR TITLE
Fix: Integrasi Artikel CMS OpenKab ke Widget Artikel Terbaru dan Halaman Publik Daftar Artikel

### DIFF
--- a/app/Http/Controllers/CMS/ArticleController.php
+++ b/app/Http/Controllers/CMS/ArticleController.php
@@ -63,6 +63,8 @@ class ArticleController extends AppBaseController
         }
         $this->articleRepository->create($input);
 
+        (new \App\Services\ArtikelService)->clearAllCache();
+
         Session::flash('success', 'Artikel berhasil disimpan.');
 
         return redirect(route('articles.index'));
@@ -135,6 +137,8 @@ class ArticleController extends AppBaseController
         }
         $article = $this->articleRepository->update($input, $id);
 
+        (new \App\Services\ArtikelService)->clearAllCache();
+
         Session::flash('success', 'Artikel berhasil diupdate.');
 
         return redirect(route('articles.index'));
@@ -159,6 +163,9 @@ class ArticleController extends AppBaseController
         $this->authorize('delete', $article);
 
         $this->articleRepository->delete($id);
+
+        (new \App\Services\ArtikelService)->clearAllCache();
+
         if (request()->ajax()) {
             return $this->sendSuccess('Artikel berhasil dihapus.');
         }

--- a/app/Http/Controllers/Web/ArtikelController.php
+++ b/app/Http/Controllers/Web/ArtikelController.php
@@ -3,8 +3,12 @@
 namespace App\Http\Controllers\Web;
 
 use App\Http\Controllers\Controller;
+use App\Models\CMS\Article;
 use App\Services\ArtikelService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\View\View;
 
 class ArtikelController extends Controller
 {
@@ -16,62 +20,94 @@ class ArtikelController extends Controller
     }
 
     /**
-     * Tampilkan daftar artikel OpenSID.
+     * Tampilkan daftar artikel gabungan (OpenKab & OpenSID).
      *
      * @param Request $request
-     * @return \Illuminate\View\View
+     * @return View
      */
-    public function index(Request $request)
+    public function index(Request $request): View
     {
         $search = $request->get('search', '');
         $categoryId = $request->get('kategori', '');
 
         $filters = [];
         if (!empty($search)) {
+            $filters['search'] = $search;
             $filters['filter[search]'] = $search;
         }
         if (!empty($categoryId)) {
+            $filters['kategori'] = $categoryId;
             $filters['filter[id_kategori]'] = $categoryId;
         }
 
-        // Ambil data melalui service
-        // Format Pagination API json format
-        $filters['page[number]'] = $request->get('page', 1);
-        $filters['page[size]'] = 6;
-        $filters['sort'] = '-tgl_upload'; // Terurut berdasarkan tanggal terbaru
+        // Ambil data gabungan melalui service
+        $combinedArticles = $this->artikelService->getCombinedArticles($filters);
 
-        // Caching ditangani oleh ArtikelService
-        $articles = $this->artikelService->artikel($filters);
+        // Pagination menggunakan LengthAwarePaginator
+        $page = max((int) $request->get('page', 1), 1);
+        $perPage = 6;
+        $offset = ($page - 1) * $perPage;
+        $itemsForCurrentPage = $combinedArticles->slice($offset, $perPage)->values();
 
-        // Filter out disabled articles just in case API returns them
-        $articles = $articles->filter(function ($item) {
-            return isset($item->enabled) && $item->enabled == 1;
-        });
+        $articles = new LengthAwarePaginator(
+            $itemsForCurrentPage,
+            $combinedArticles->count(),
+            $perPage,
+            $page,
+            ['path' => $request->url(), 'query' => $request->query()]
+        );
 
         return view('web.artikel.index', [
             'title' => 'Artikel Berita',
             'articles' => $articles,
             'search' => $search,
-            'categoryId' => $categoryId
+            'categoryId' => $categoryId,
         ]);
     }
 
     /**
-     * Tampilkan detail artikel OpenSID.
+     * Endpoint JSON untuk widget Artikel Terbaru di Beranda.
      *
-     * @param int $id
-     * @return \Illuminate\View\View
+     * @param Request $request
+     * @return JsonResponse
+     */
+    public function terbaru(Request $request): JsonResponse
+    {
+        $limit = max((int) $request->get('limit', 6), 1);
+        $articles = $this->artikelService->getArtikelTerbaru($limit);
+
+        return response()->json([
+            'status' => 'success',
+            'data' => $articles,
+        ]);
+    }
+
+    /**
+     * Tampilkan detail artikel OpenSID (dengan fallback ke artikel CMS lokal jika ID/slug cocok).
+     *
+     * @param int|string $id
+     * @return View|\Illuminate\Http\RedirectResponse
      */
     public function show($id)
     {
-        $article = $this->artikelService->artikelById($id);
+        $article = is_numeric($id) ? $this->artikelService->artikelById((int) $id) : null;
 
-        if (!$article || !isset($article->enabled) || $article->enabled == 0) {
-            abort(404, 'Artikel tidak ditemukan atau tidak aktif');
+        if ($article && isset($article->enabled) && $article->enabled == 1) {
+            return view('web.artikel.show', [
+                'object' => $article,
+            ]);
         }
 
-        return view('web.artikel.show', [
-            'object' => $article
-        ]);
+        // Fallback: Cek apakah ID/slug merujuk pada artikel CMS OpenKab lokal
+        $localArticle = Article::where('id', $id)
+            ->orWhere('slug', $id)
+            ->first();
+
+        if ($localArticle && $localArticle->state == Article::PUBLISH && $localArticle->published_at <= now()) {
+            return redirect()->route('article', ['aSlug' => $localArticle->slug]);
+        }
+
+        abort(404, 'Artikel tidak ditemukan atau tidak aktif');
     }
 }
+

--- a/app/Services/ArtikelService.php
+++ b/app/Services/ArtikelService.php
@@ -2,8 +2,10 @@
 
 namespace App\Services;
 
+use App\Models\CMS\Article;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
 use stdClass;
 
 class ArtikelService extends BaseApiService
@@ -33,7 +35,51 @@ class ArtikelService extends BaseApiService
     }
 
     /**
-     * Mendapatkan daftar artikel dengan filter opsional
+     * Mendapatkan daftar artikel dari CMS lokal OpenKab
+     *
+     * @param  array<int|string, mixed>  $filters
+     */
+    public function getLocalArticles(array $filters = []): Collection
+    {
+        $search = $filters['search'] ?? $filters['filter[search]'] ?? null;
+        $categoryId = $filters['kategori'] ?? $filters['category_id'] ?? $filters['filter[id_kategori]'] ?? null;
+
+        $query = Article::with('category')
+            ->where('state', Article::PUBLISH)
+            ->where('published_at', '<=', now());
+
+        if (! empty($search)) {
+            $query->where(function ($q) use ($search) {
+                $q->where('title', 'like', "%{$search}%")
+                    ->orWhere('content', 'like', "%{$search}%");
+            });
+        }
+
+        if (! empty($categoryId)) {
+            $query->where('category_id', $categoryId);
+        }
+
+        $articles = $query->orderBy('published_at', 'desc')->get();
+
+        return $articles->map(function (Article $article): stdClass {
+            return (object) [
+                'id' => $article->id,
+                'slug' => $article->slug,
+                'judul' => $article->title,
+                'isi' => $article->content,
+                'gambar' => $article->thumbnail ? Storage::url($article->thumbnail) : null,
+                'id_kategori' => $article->category_id,
+                'kategori_nama' => $article->category?->name ?? 'Berita OpenKab',
+                'tgl_upload' => $article->published_at ? $article->published_at->format('Y-m-d H:i:s') : ($article->created_at ? $article->created_at->format('Y-m-d H:i:s') : ''),
+                'enabled' => 1,
+                'source' => 'openkab',
+                'detail_url' => route('article', ['aSlug' => $article->slug]),
+            ];
+        });
+    }
+
+    /**
+     * Mendapatkan daftar artikel dari API upstream OpenSID dengan filter opsional
      *
      * @param  array<int|string, mixed>  $filters
      */
@@ -46,33 +92,72 @@ class ArtikelService extends BaseApiService
 
         // Ambil dari cache dulu
         return Cache::remember($cacheKey, $this->cacheTtl, function () use ($filters): Collection {
-            $data = $this->apiRequest('/api/v1/artikel/list', $filters);
+            try {
+                $data = $this->apiRequest('/api/v1/artikel/list', $filters);
 
-            if (empty($data)) {
-                return collect([]);
-            }
-
-            return collect($data)->map(function (array $item): stdClass {
-                // Return 'attributes' but with 'id' populated
-                $attributes = $item['attributes'] ?? [];
-                $attributes['id'] = $item['id'] ?? null;
-
-                // Fetch detail to enrich with gambar and isi if missing
-                if (isset($attributes['id']) && (! isset($attributes['gambar']) || ! isset($attributes['isi']))) {
-                    $detail = $this->artikelById((int) $attributes['id']);
-                    if ($detail !== null) {
-                        $attributes['gambar'] = $detail->gambar ?? null;
-                        $attributes['isi'] = $detail->isi ?? null;
-                    }
+                if (empty($data)) {
+                    return collect([]);
                 }
 
-                return (object) $attributes;
-            });
+                return collect($data)->map(function (array $item): stdClass {
+                    // Return 'attributes' but with 'id' populated
+                    $attributes = $item['attributes'] ?? [];
+                    $attributes['id'] = $item['id'] ?? null;
+                    $attributes['source'] = 'opensid';
+                    $attributes['detail_url'] = isset($attributes['id']) ? route('web.artikel.show', $attributes['id']) : '#';
+
+                    // Fetch detail to enrich with gambar and isi if missing
+                    if (isset($attributes['id']) && (! isset($attributes['gambar']) || ! isset($attributes['isi']))) {
+                        $detail = $this->artikelById((int) $attributes['id']);
+                        if ($detail !== null) {
+                            $attributes['gambar'] = $detail->gambar ?? null;
+                            $attributes['isi'] = $detail->isi ?? null;
+                        }
+                    }
+
+                    return (object) $attributes;
+                });
+            } catch (\Throwable $e) {
+                return collect([]);
+            }
         });
     }
 
     /**
-     * Mendapatkan detail artikel berdasarkan ID
+     * Mendapatkan gabungan artikel OpenKab lokal dan artikel OpenSID API, terurut berdasarkan tanggal terbaru
+     *
+     * @param  array<int|string, mixed>  $filters
+     */
+    public function getCombinedArticles(array $filters = []): Collection
+    {
+        $cacheKey = $this->buildCacheKey('artikel_combined', $filters);
+        $this->registerCacheKey($cacheKey);
+
+        return Cache::remember($cacheKey, $this->cacheTtl, function () use ($filters): Collection {
+            $localArticles = $this->getLocalArticles($filters);
+            $apiArticles = $this->artikel($filters);
+
+            // Filter out disabled articles just in case
+            $apiArticles = $apiArticles->filter(function ($item) {
+                return isset($item->enabled) && $item->enabled == 1;
+            });
+
+            return $localArticles->concat($apiArticles)->sortByDesc(function ($item) {
+                return $item->tgl_upload ?? '1970-01-01 00:00:00';
+            })->values();
+        });
+    }
+
+    /**
+     * Mendapatkan daftar artikel terbaru gabungan untuk widget beranda
+     */
+    public function getArtikelTerbaru(int $limit = 6): Collection
+    {
+        return $this->getCombinedArticles(['page[size]' => $limit])->take($limit)->values();
+    }
+
+    /**
+     * Mendapatkan detail artikel berdasarkan ID (dari API)
      */
     public function artikelById(int $id): ?stdClass
     {
@@ -82,12 +167,16 @@ class ArtikelService extends BaseApiService
         $this->registerCacheKey($cacheKey);
 
         return Cache::remember($cacheKey, $this->cacheTtl, function () use ($id): ?stdClass {
-            $data = $this->apiRequest('/api/v1/artikel/tampil', [
-                'id' => $id,
-            ]);
+            try {
+                $data = $this->apiRequest('/api/v1/artikel/tampil', [
+                    'id' => $id,
+                ]);
 
-            if (is_array($data) && count($data) > 0) {
-                return (object) $data;
+                if (is_array($data) && count($data) > 0) {
+                    return (object) $data;
+                }
+            } catch (\Throwable $e) {
+                return null;
             }
 
             return null;
@@ -141,3 +230,4 @@ class ArtikelService extends BaseApiService
         Cache::forget($this->cacheRegistryKey);
     }
 }
+

--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -2,6 +2,8 @@ Di rilis ini, versi 2608.0.2 berisi penambahan dan perbaikan yang diminta penggu
 
 #### Penambahan Fitur
 
+1. [#1268](https://github.com/OpenSID/OpenKab/issues/1268) Penambahan fitur artikel tidak tampil di website.
+
 #### Perbaikan BUG
 
 1. [#1105](https://github.com/OpenSID/OpenKab/issues/1105) Perbaikan filter kecamatan tampil tanpa memilih kabupaten terlebih dahulu.

--- a/resources/views/web/article.blade.php
+++ b/resources/views/web/article.blade.php
@@ -9,20 +9,65 @@
                     <nav aria-label="breadcrumb animated fadeIn">
                         <ol class="breadcrumb text-uppercase">
                             <li class="breadcrumb-item"><a href="/">Beranda</a></li>
-                            <li class="breadcrumb-item"><a href="#">Halaman</a></li>
-                            <li class="breadcrumb-item text-body active" aria-current="page">{{ $object->title }}</li>
+                            <li class="breadcrumb-item"><a href="{{ route('web.artikel.index') }}">Artikel</a></li>
+                            <li class="breadcrumb-item text-body active" aria-current="page">{{ Str::limit($object->title ?? 'Detail Artikel', 30) }}</li>
                         </ol>
                     </nav>
                 </div>
             </div>
         </div>
         <!-- Header End -->
+
         <!-- Konten Halaman -->
-        <div class="container-fluid">
-            <div class="col-lg-12 wow fadeIn" data-wow-delay="0.5s">
-                {!! clean($object->content) !!}
+        <div class="container-fluid px-4 mb-5">
+            <div class="row justify-content-center">
+                <div class="col-lg-10 wow fadeIn" data-wow-delay="0.1s">
+                    <div class="card border-0 shadow-sm">
+                        <div class="card-header bg-white pb-0 border-0 text-center">
+                            <h2 class="mt-4 mb-3">{{ $object->title ?? '' }}</h2>
+                            <div class="d-flex justify-content-center gap-3 mb-4 text-muted">
+                                <span><i class="fa fa-folder-open text-primary me-2"></i>{{ $object->category?->name ?? 'Berita' }}</span>
+                                <span><i class="fa fa-calendar-alt text-primary me-2"></i>{{ $object->published_at ? \Carbon\Carbon::parse($object->published_at)->translatedFormat('d F Y') : '' }}</span>
+                            </div>
+                        </div>
+
+                        @if (!empty($object->thumbnail))
+                            <img src="{{ Storage::url($object->thumbnail) }}" class="card-img-top img-fluid px-4 mb-3 rounded"
+                                alt="{{ $object->title ?? '' }}" style="max-height: 500px; object-fit: contain;">
+                        @endif
+
+                        <div class="card-body p-4 p-md-5">
+                            <div class="artikel-content">
+                                {!! clean($object->content ?? '') !!}
+                            </div>
+                        </div>
+
+                        <div class="card-footer bg-white text-center py-4 border-top">
+                            <a href="{{ route('web.artikel.index') }}" class="btn btn-outline-primary px-4">
+                                <i class="fa fa-arrow-left me-2"></i>Kembali ke Daftar Artikel
+                            </a>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
         <!-- Konten Halaman -->
     </div>
 @endsection
+
+@push('styles')
+    <style>
+        .artikel-content img {
+            max-width: 100%;
+            height: auto;
+            border-radius: 8px;
+            margin: 1rem 0;
+        }
+
+        .artikel-content {
+            line-height: 1.8;
+            font-size: 1.05rem;
+        }
+    </style>
+@endpush
+

--- a/resources/views/web/artikel/index.blade.php
+++ b/resources/views/web/artikel/index.blade.php
@@ -54,6 +54,9 @@
                             <div class="card-body d-flex flex-column">
                                 <h5 class="card-title">{{ $article->judul ?? '' }}</h5>
                                 <div class="mb-2">
+                                    @if (isset($article->source) && $article->source === 'openkab')
+                                        <span class="badge bg-success me-1">OpenKab</span>
+                                    @endif
                                     <span class="badge bg-primary">{{ $article->kategori_nama ?? 'Kategori' }}</span>
                                 </div>
                                 <div class="card-text flex-grow-1">
@@ -61,13 +64,11 @@
                                 </div>
                                 <div class="d-flex justify-content-between align-items-center mt-3">
                                     <div>
-                                        @if (isset($article->id))
-                                        <a href="{{ route('web.artikel.show', $article->id) }}"
+                                        <a href="{{ $article->detail_url ?? route('web.artikel.show', $article->id) }}"
                                             class="text-decoration-none btn btn-sm btn-outline-primary">Selengkapnya</a>
-                                        @endif
                                     </div>
                                     <small class="text-muted">
-                                        {{ isset($article->tgl_upload) ? \Carbon\Carbon::parse($article->tgl_upload)->translatedFormat('d F Y') : '' }}
+                                        {{ isset($article->tgl_upload) && !empty($article->tgl_upload) ? \Carbon\Carbon::parse($article->tgl_upload)->translatedFormat('d F Y') : '' }}
                                     </small>
                                 </div>
                             </div>
@@ -82,9 +83,11 @@
                 @endforelse
             </div>
 
-            <!-- Mengingat ini adalah array/collection dari API (bukan standard Laravel paginator), 
-                     UI pagination native agak tricky untuk di-render otomatis. 
-                     Kita tampilkan tombol Muat Lebih Banyak dengan parameter halaman jika diperlukan -->
+            @if ($articles->hasPages())
+                <div class="d-flex justify-content-center mb-5">
+                    {{ $articles->links('pagination::bootstrap-5') }}
+                </div>
+            @endif
         </div>
         <!-- Konten Halaman -->
     </div>

--- a/resources/views/web/partials/artikel_terbaru.blade.php
+++ b/resources/views/web/partials/artikel_terbaru.blade.php
@@ -44,50 +44,45 @@
         document.addEventListener("DOMContentLoaded", function (event) {
             "use strict";
 
-            const urlArtikel = new URL("{{ config('app.databaseGabunganUrl') . '/api/v1/artikel-public/list' }}");
-            
-            const routeDetailBase = "{{ url('artikel-opensid') }}";
+            const urlArtikel = "{{ route('web.artikel.terbaru') }}";
 
             $.ajax({
-                url: urlArtikel.href,
-                method: 'GET',                
+                url: urlArtikel,
+                method: 'GET',
                 dataType: 'json',
-                
                 data: {
-                    "page[number]": 1,
-                    "page[size]": 6,
-                    "sort": "-tgl_upload",
-                    "filter[enabled]": "1" // Only get active articles
+                    limit: 6
                 },
                 success: function (result) {
                     if (result.data && result.data.length > 0) {
                         let htmlContent = '';
 
                         result.data.forEach((item) => {
-                            let attr = item.attributes || {};
                             // Use dummy image if none provided
-                            let imgSrc = attr.gambar ? attr.gambar : `data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22100%25%22%20height%3D%22225%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20225%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_18e19c362b5%20text%20%7B%20fill%3A%23eceeef%3Bfont-weight%3Abold%3Bfont-family%3AArial%2C%20Helvetica%2C%20Open%20Sans%2C%20sans-serif%2C%20monospace%3Bfont-size%3A11pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_18e19c362b5%22%3E%3Crect%20width%3D%22100%25%22%20height%3D%22225%22%20fill%3D%22%2355595c%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%2250%25%22%20y%3D%2250%25%22%20text-anchor%3D%22middle%22%3EThumbnail%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E`;
+                            let imgSrc = item.gambar ? item.gambar : `data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22100%25%22%20height%3D%22225%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20225%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_18e19c362b5%20text%20%7B%20fill%3A%23eceeef%3Bfont-weight%3Abold%3Bfont-family%3AArial%2C%20Helvetica%2C%20Open%20Sans%2C%20sans-serif%2C%20monospace%3Bfont-size%3A11pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_18e19c362b5%22%3E%3Crect%20width%3D%22100%25%22%20height%3D%22225%22%20fill%3D%22%2355595c%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%2250%25%22%20y%3D%2250%25%22%20text-anchor%3D%22middle%22%3EThumbnail%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E`;
 
                             // Strip HTML tags from isi
                             let tmp = document.createElement("DIV");
-                            tmp.innerHTML = attr.isi || '';
+                            tmp.innerHTML = item.isi || '';
                             let textLength = 100;
                             let plainText = tmp.textContent || tmp.innerText || "";
                             let isiExcerpt = plainText.length > textLength ? plainText.substring(0, textLength) + "..." : plainText;
 
                             // Format date simple
-                            let dateStr = attr.tgl_upload ? attr.tgl_upload.split(' ')[0] : '';
-
-                            let detailUrl = `${routeDetailBase}/${item.id}`;
+                            let dateStr = item.tgl_upload ? item.tgl_upload.split(' ')[0] : '';
+                            let detailUrl = item.detail_url || '#';
+                            let kategori = item.kategori_nama || 'Kategori';
+                            let badgeSource = item.source === 'openkab' ? '<span class="badge bg-success me-1">OpenKab</span>' : '';
 
                             htmlContent += `
                                     <div class="col-lg-4 col-md-6 wow fadeInUp" data-wow-delay="0.1s">
                                         <div class="card shadow-sm h-100">
-                                            <img src="${imgSrc}" width="100%" height="225" class="card-img-top object-fit-cover" alt="${attr.judul || ''}">
+                                            <img src="${imgSrc}" width="100%" height="225" class="card-img-top object-fit-cover" alt="${item.judul || ''}">
                                             <div class="card-body d-flex flex-column">
-                                                <h5 class="card-title text-truncate">${attr.judul || ''}</h5>
+                                                <h5 class="card-title text-truncate">${item.judul || ''}</h5>
                                                 <div class="mb-2">
-                                                    <span class="badge bg-primary">${attr.kategori_nama || 'Kategori'}</span>
+                                                    ${badgeSource}
+                                                    <span class="badge bg-primary">${kategori}</span>
                                                 </div>
                                                 <div class="card-text flex-grow-1" style="font-size: 0.9rem;">
                                                     ${isiExcerpt}
@@ -114,7 +109,7 @@
                 error: function () {
                     $('.replace-content-artikel').html(`
                             <div class="col-12 text-center text-danger py-4">
-                                <i>Gagal memuat artikel jaringan atau server bermasalah</i>
+                                <i>Gagal memuat artikel terbaru</i>
                             </div>
                         `);
                 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -445,6 +445,7 @@ Route::get('/statistik-bantuan', [PresisiController::class, 'bantuan'])->name('p
 
 Route::middleware(['website.enable', 'log.visitor'])->group(function () {
     Route::get('/', [PageController::class, 'getIndex'])->name('web.index');
+    Route::get('artikel/terbaru', [ArtikelController::class, 'terbaru'])->name('web.artikel.terbaru');
     Route::get('artikel-opensid', [ArtikelController::class, 'index'])->name('web.artikel.index');
     Route::get('artikel-opensid/{id}', [ArtikelController::class, 'show'])->name('web.artikel.show');
     Route::get('a/{aSlug}', [PageController::class, 'getArticle'])->name('article');

--- a/tests/Feature/ArtikelWebTest.php
+++ b/tests/Feature/ArtikelWebTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use App\Models\CMS\Article;
+use App\Models\CMS\Category;
 use App\Services\ArtikelService;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
@@ -22,7 +24,7 @@ class ArtikelWebTest extends BaseTestCase
 
         // Mock the ArtikelService
         $mockService = Mockery::mock(ArtikelService::class);
-        $mockService->shouldReceive('artikel')->andReturn(collect([
+        $mockService->shouldReceive('getCombinedArticles')->andReturn(collect([
             (object) [
                 'id' => 1,
                 'judul' => 'Test Artikel OpenSID',
@@ -31,18 +33,62 @@ class ArtikelWebTest extends BaseTestCase
                 'kategori_nama' => 'Berita Desa',
                 'tgl_upload' => '2023-10-01 10:00:00',
                 'enabled' => 1,
+                'source' => 'opensid',
+                'detail_url' => route('web.artikel.show', 1),
             ]
         ]));
 
         $this->app->instance(ArtikelService::class, $mockService);
 
         $response = $this->get(route('web.artikel.index'));
-        $response->dump();
         $response->assertStatus(200);
         $response->assertViewIs('web.artikel.index');
         $response->assertSee('Artikel Berita');
         $response->assertSee('Test Artikel OpenSID');
         $response->assertSee('Berita Desa');
+    }
+
+    #[Test]
+    public function it_displays_openkab_cms_articles_in_public_index()
+    {
+        $this->withoutMiddleware([\App\Http\Middleware\WebsiteEnable::class]);
+
+        $category = Category::factory()->create(['name' => 'Kategori OpenKab']);
+        $localArticle = Article::factory()->create([
+            'category_id' => $category->id,
+            'title' => 'Judul Artikel OpenKab CMS',
+            'content' => 'Konten artikel cms openkab lokal',
+            'state' => Article::PUBLISH,
+            'published_at' => now()->subDay(),
+        ]);
+
+        $response = $this->get(route('web.artikel.index'));
+        $response->assertStatus(200);
+        $response->assertSee('Judul Artikel OpenKab CMS');
+        $response->assertSee('OpenKab');
+    }
+
+    #[Test]
+    public function it_can_access_artikel_terbaru_json_endpoint()
+    {
+        $this->withoutMiddleware([\App\Http\Middleware\WebsiteEnable::class]);
+
+        $category = Category::factory()->create(['name' => 'Kategori OpenKab']);
+        $localArticle = Article::factory()->create([
+            'category_id' => $category->id,
+            'title' => 'Berita Terkini OpenKab',
+            'content' => 'Cuplikan berita terkini',
+            'state' => Article::PUBLISH,
+            'published_at' => now(),
+        ]);
+
+        $response = $this->get(route('web.artikel.terbaru'));
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'status',
+            'data',
+        ]);
+        $response->assertSee('Berita Terkini OpenKab');
     }
 
     #[Test]
@@ -72,13 +118,35 @@ class ArtikelWebTest extends BaseTestCase
     }
 
     #[Test]
+    public function it_redirects_to_local_cms_article_if_id_matches_local_article()
+    {
+        $this->withoutMiddleware([\App\Http\Middleware\WebsiteEnable::class]);
+
+        $category = Category::factory()->create();
+        $localArticle = Article::factory()->create([
+            'category_id' => $category->id,
+            'title' => 'Artikel Lokal Redirect',
+            'slug' => 'artikel-lokal-redirect',
+            'state' => Article::PUBLISH,
+            'published_at' => now()->subDay(),
+        ]);
+
+        $mockService = Mockery::mock(ArtikelService::class);
+        $mockService->shouldReceive('artikelById')->with($localArticle->id)->andReturn(null);
+        $this->app->instance(ArtikelService::class, $mockService);
+
+        $response = $this->get(route('web.artikel.show', ['id' => $localArticle->id]));
+        $response->assertRedirect(route('article', ['aSlug' => $localArticle->slug]));
+    }
+
+    #[Test]
     public function it_aborts_404_for_disabled_or_missing_artikel()
     {
         $this->withoutMiddleware([\App\Http\Middleware\WebsiteEnable::class]);
 
         // Mock the ArtikelService
         $mockService = Mockery::mock(ArtikelService::class);
-        $mockService->shouldReceive('artikelById')->with(99)->andReturn(null);
+        $mockService->shouldReceive('artikelById')->with(999999)->andReturn(null);
 
         $mockService->shouldReceive('artikelById')->with(2)->andReturn((object) [
             'id' => 2,
@@ -89,7 +157,7 @@ class ArtikelWebTest extends BaseTestCase
         $this->app->instance(ArtikelService::class, $mockService);
 
         // Test non-existent article
-        $response404 = $this->get(route('web.artikel.show', ['id' => 99]));
+        $response404 = $this->get(route('web.artikel.show', ['id' => 999999]));
         $response404->assertStatus(404);
 
         // Test disabled article
@@ -97,3 +165,4 @@ class ArtikelWebTest extends BaseTestCase
         $responseDisabled->assertStatus(404);
     }
 }
+


### PR DESCRIPTION

issue # https://github.com/OpenSID/OpenKab/issues/1268

## 🎯 Deskripsi

Pull request ini mengintegrasikan artikel yang dibuat melalui CMS OpenKab (`/cms/articles` / tabel `articles`) ke dalam antarmuka publik, yaitu:
1. **Widget Artikel Terbaru di Beranda (`/`)**: Menampilkan gabungan artikel terbaru baik dari CMS lokal OpenKab maupun dari API upstream OpenSID secara otomatis dan terurut berdasarkan tanggal publikasi terbaru.
2. **Halaman Publik Daftar Artikel (`/artikel-opensid`)**: Menampilkan daftar artikel gabungan lengkap dengan dukungan pencarian (*search*), penanda sumber artikel (*badge OpenKab*), dan paginasi (*LengthAwarePaginator*).
3. **Penyelarasan Halaman Detail Artikel CMS (`/a/{slug}`)**: Mempercantik antarmuka detail artikel CMS lokal agar konsisten dengan artikel publik (memiliki gambar utama, metadata kategori, tanggal rilis, dan tombol kembali ke daftar artikel).

Sebelumnya, widget Beranda dan halaman daftar artikel hanya mengambil data dari API Database Gabungan (`API_DATABASE_GABUNGAN_HOST/api/v1/artikel/...`), sehingga artikel lokal yang ditulis oleh pengelola CMS OpenKab tidak muncul pada halaman depan maupun daftar berita publik.

Dengan PR ini, arsitektur data artikel di OpenKab telah disatukan pada layer `ArtikelService` dengan mekanisme *caching* dan *cache invalidation* otomatis, serta *graceful fallback* jika API upstream sedang tidak dapat diakses.

---

## 🛠️ Perubahan yang Dilakukan

### 1. `app/Services/ArtikelService.php`

**Feature — Penyatuan Data Artikel Lokal CMS dan Upstream API:**
- Menambahkan method `getLocalArticles()` untuk mengambil artikel CMS lokal yang aktif/terbit (`state = 1` dan `published_at <= now()`) serta memetakan atributnya ke struktur objek standar (`id`, `judul`, `isi`, `gambar`, `kategori_nama`, `tgl_upload`, `source`, `detail_url`).
- Menambahkan method `getCombinedArticles()` untuk menggabungkan artikel lokal dan artikel upstream API dengan pengurutan berdasarkan tanggal terbaru (`tgl_upload` *descending*).
- Menambahkan method `getArtikelTerbaru(int $limit = 6)` untuk menyuplai data widget beranda.
- Membungkus panggilan API dengan penanganan error (*try-catch*) agar jika API eksternal mengalami kendala, artikel CMS lokal tetap dapat diakses dengan cepat dan andal.

```diff
+    public function getLocalArticles(array $filters = []): Collection
+    {
+        $query = Article::with('category')
+            ->where('state', Article::PUBLISH)
+            ->where('published_at', '<=', now());
+        ...
+    }
+
+    public function getCombinedArticles(array $filters = []): Collection
+    {
+        $localArticles = $this->getLocalArticles($filters);
+        $apiArticles = $this->artikel($filters);
+        return $localArticles->concat($apiArticles)->sortByDesc('tgl_upload')->values();
+    }
```

---

### 2. `routes/web.php` & `app/Http/Controllers/Web/ArtikelController.php`

**Feature & Fix — Endpoint JSON Artikel Terbaru, Paginasi Gabungan, dan Fallback Detail:**
- Mendaftarkan route publik `Route::get('artikel/terbaru', [ArtikelController::class, 'terbaru'])->name('web.artikel.terbaru')`.
- Memperbarui `ArtikelController::index()` untuk merender data gabungan dengan paginasi Laravel (`LengthAwarePaginator`).
- Menambahkan method `ArtikelController::terbaru()` yang mengembalikan JSON data artikel terbaru untuk kebutuhan AJAX widget beranda.
- Memperbarui `ArtikelController::show($id)` dengan *fallback redirect* ke `route('article', $localArticle->slug)` jika `$id` yang diakses adalah ID/slug artikel CMS lokal.

```diff
+    Route::get('artikel/terbaru', [ArtikelController::class, 'terbaru'])->name('web.artikel.terbaru');
```

---

### 3. `app/Http/Controllers/CMS/ArticleController.php`

**Fix — Cache Invalidation Otomatis:**
- Memanggil `(new ArtikelService)->clearAllCache()` saat artikel CMS disimpan (`store`), diperbarui (`update`), atau dihapus (`destroy`) agar data di frontend langsung terbarui tanpa menunggu kedaluwarsa TTL cache.

---

### 4. `resources/views/web/partials/artikel_terbaru.blade.php`

**Refactor — Mengarahkan Permintaan AJAX ke Endpoint Internal:**
- Mengubah URL AJAX dari yang sebelumnya memanggil endpoint eksternal secara langsung di browser klien menjadi memanggil endpoint internal `route('web.artikel.terbaru')`.
- Menyesuaikan pembacaan respons JSON dengan atribut standar dan tautan dinamis `detail_url` serta lencana sumber (`OpenKab`).

---

### 5. `resources/views/web/artikel/index.blade.php` & `resources/views/web/article.blade.php`

**UI/UX — Navigasi Dinamis, Lencana Sumber, dan Tampilan Detail:**
- Menggunakan `$article->detail_url` pada tombol "Selengkapnya" pada daftar artikel (`web.artikel.index`).
- Menampilkan lencana sumber `<span class="badge bg-success">OpenKab</span>` untuk memudahkan identifikasi artikel CMS.
- Menambahkan kontrol paginasi standar Bootstrap 5 (`$articles->links('pagination::bootstrap-5')`).
- Mempercantik halaman detail artikel CMS (`web.article`) dengan gambar utama, metadata kategori, tanggal rilis, dan tombol kembali ke daftar artikel.

---

### 6. `tests/Feature/ArtikelWebTest.php`

**Test — Penambahan dan Pembaruan Test Suite Artikel Web:**
- Menguji aksesibilitas halaman daftar artikel publik (`web.artikel.index`).
- Menguji kemunculan artikel CMS OpenKab di daftar artikel publik lengkap dengan verifikasi lencana `OpenKab`.
- Menguji endpoint JSON artikel terbaru (`web.artikel.terbaru`).
- Menguji *fallback redirect* halaman detail artikel jika merujuk ke artikel CMS lokal.
- Menguji penanganan status 404 untuk artikel non-aktif atau tidak ditemukan.

---

## ✅ Test Cases yang Diimplementasikan

- [x] Artikel CMS OpenKab yang berstatus **Terbitkan (Publish)** dan tanggal publikasinya valid tampil pada halaman daftar artikel publik (`/artikel-opensid`).
- [x] Artikel CMS OpenKab terbaru tampil di widget **Artikel Terbaru** pada Beranda (`/`).
- [x] Tombol "Selengkapnya" mengarahkan pengguna ke URL detail yang sesuai (`/a/{slug}` untuk artikel OpenKab, dan `/artikel-opensid/{id}` untuk artikel OpenSID).
- [x] Fitur pencarian artikel pada `/artikel-opensid?search=...` dapat memfilter artikel CMS lokal dan artikel API.
- [x] Paginasi pada halaman daftar artikel berfungsi dengan benar.
- [x] Mengubah atau menambah artikel di CMS otomatis membersihkan cache artikel publik.
- [x] Seluruh *automated test* pada `ArtikelWebTest.php` lolos (*pass*) tanpa error.

---

## 📸 Cara Menjalankan Uji Coba Manual

1. Jalankan aplikasi OpenKab dan login sebagai admin.
2. Buka menu **Website > Artikel** (`http://openkab.test/cms/articles`) dan buat artikel baru dengan status **Terbitkan**.
3. Buka halaman Beranda (`http://openkab.test/`).
   - ✅ **Seharusnya:** Artikel baru tersebut muncul di bagian **Artikel Terbaru**.
4. Buka halaman daftar artikel (`http://openkab.test/artikel-opensid`).
   - ✅ **Seharusnya:** Artikel CMS muncul dengan lencana **OpenKab** dan tombol "Selengkapnya".
5. Klik tombol "Selengkapnya" pada artikel OpenKab tersebut.
   - ✅ **Seharusnya:** Halaman detail artikel terbuka di `/a/{slug}` dengan tampilan lengkap beserta gambar dan metadata.
6. Coba gunakan fitur pencarian pada halaman daftar artikel dengan memasukkan kata kunci judul artikel yang baru dibuat.
   - ✅ **Seharusnya:** Hasil pencarian menampilkan artikel yang sesuai.

---

## 🤖 Cara Menjalankan Uji Coba Otomatis (Automated Test)

Jalankan perintah berikut di terminal:

```bash
php artisan test tests/Feature/ArtikelWebTest.php
```

Untuk menjalankan seluruh pengujian terkait modul website dan CMS:

```bash
php artisan test tests/Feature/PageControllerWebsiteTest.php tests/Feature/ArticleControllerCmsTest.php tests/Feature/CategoryControllerCmsTest.php tests/Feature/XssPreventionTest.php
```

---

## 📸 Screenshot atau Video
<img width="1647" height="464" alt="image" src="https://github.com/user-attachments/assets/96383e21-b307-4d30-aa8d-249b6761586b" />
<img width="1215" height="391" alt="image" src="https://github.com/user-attachments/assets/3fb880b7-7d04-4c18-aa13-463e276eea68" />


---

## ⚠️ Catatan Penting

> - Artikel CMS lokal yang berstatus **Draft** (`state = 0`) atau yang memiliki tanggal rilis di masa depan (`published_at > now()`) **tidak akan ditampilkan** di frontend publik sampai statusnya diterbitkan dan tanggal publikasinya terpenuhi.
> - Mekanisme penggabungan artikel tetap berjalan normal meskipun koneksi ke upstream API Database Gabungan terputus.
