### PR TITLE
Fix default data pada IdentitasSeeder

### DIFF
--- a/catatan_rilis.md
+++ b/catatan_rilis.md
@@ -16,3 +16,4 @@ Di rilis ini, versi 2608.0.2 berisi penambahan dan perbaikan yang diminta penggu
 #### Perubahan Teknis
 
 
+1. [#1270](https://github.com/OpenSID/OpenKab/issues/1270) Perbaiki seeder data identitas.

--- a/database/seeders/IdentitasSeeder.php
+++ b/database/seeders/IdentitasSeeder.php
@@ -16,16 +16,16 @@ class IdentitasSeeder extends Seeder
     public function run()
     {
         $defaultData = [
-            'nama_aplikasi' => 'Simatik',
-            'nama_kabupaten' => 'KOTA BIMA',
-            'kode_kabupaten' => '52.72',
-            'nama_provinsi' => 'Nusa Tenggara Barat',
-            'kode_provinsi' => '52',
-            'sebutan_kab' => 'Kota'
+            'nama_aplikasi' => 'OpenKab',
+            'nama_kabupaten' => 'Belum Ditentukan',
+            'kode_kabupaten' => '00.00',
+            'nama_provinsi' => 'Belum Ditentukan',
+            'kode_provinsi' => '00',
+            'sebutan_kab' => 'Kabupaten'
         ];
         if(Schema::hasColumn('identitas', 'sebutan_desa')){
-            $defaultData['sebutan_desa'] = 'Kelurahan';
+            $defaultData['sebutan_desa'] = 'Desa';
         }
-        return Identitas::create($defaultData);
+        Identitas::create($defaultData);
     }
 }


### PR DESCRIPTION
# Pull Request: Fix default data pada IdentitasSeeder

## Description

Perbaikan data default pada `database/seeders/IdentitasSeeder.php` yang sebelumnya menggunakan data milik Kota Bima (Simatik, kode 52.72). Data spesifik ini membuat bingung pengguna karena seolah-olah identitas aplikasi sudah lengkap padahal belum tentu sesuai dengan kabupaten yang menggunakannya.

### Changes made:

1. **[Bug Fix]**: Mengganti `nama_aplikasi` dari `'Simatik'` menjadi `'OpenKab'`
2. **[Bug Fix]**: Mengganti `nama_kabupaten` dari `'KOTA BIMA'` menjadi `'Belum Ditentukan'`
3. **[Bug Fix]**: Mengganti `kode_kabupaten` dari `'52.72'` menjadi `'00.00'`
4. **[Bug Fix]**: Mengganti `nama_provinsi` dari `'Nusa Tenggara Barat'` menjadi `'Belum Ditentukan'`
5. **[Bug Fix]**: Mengganti `kode_provinsi` dari `'52'` menjadi `'00'`
6. **[Bug Fix]**: Mengganti `sebutan_kab` dari `'Kota'` menjadi `'Kabupaten'`
7. **[Bug Fix]**: Mengganti `sebutan_desa` dari `'Kelurahan'` menjadi `'Desa'`
8. **[Bug Fix]**: Menghapus `return` statement pada method `run()` (seharusnya void)

### Reason for change:

- **Konsistensi**: Seeder seharusnya menyediakan data default generik, bukan data spesifik daerah tertentu
- **Menghindari kebingungan**: Pengguna kabupaten lain (seperti sikades.bimakab.go.id) menjadi bingung karena data identitas sudah terisi dengan data Kota Bima
- **Ketepatan**: Data placeholder `'Belum Ditentukan'` dan `'00.00'` lebih jelas sebagai penanda bahwa data belum diisi

### Impact of change:

✅ **Clarity**: Pengguna baru langsung tahu bahwa data identitas belum diisi
✅ **Consistency**: Seeder tidak lagi memihak pada daerah tertentu
✅ **Correctness**: Mengembalikan return type ke `void` sesuai konvensi Laravel seeder

## Related Issue

- Solution for fix related to issue #1270

[https://github.com/OpenSID/OpenKab/issues/1270](https://github.com/OpenSID/OpenKab/issues/1270)

## Steps to Reproduce

### Before fix (problem):
1. Jalankan fresh install atau fresh database migration
2. Jalankan seeder `php artisan db:seed`
3. Cek tabel `identitas`
4. ❌ Data identitas terisi dengan data Kota Bima (Simatik, kode 52.72)
5. ❌ Pengguna kabupaten lain bingung karena identitas seolah sudah lengkap

### After fix (solution):
1. Jalankan fresh install atau fresh database migration
2. Jalankan seeder `php artisan db:seed`
3. Cek tabel `identitas`
4. ✅ Data identitas terisi dengan data default generik (`Belum Ditentukan`, `00.00`)
5. ✅ Pengguna tahu bahwa data identitas perlu diisi manual

## Checklist

- [x] I have complied with [script writing rules](https://github.com/OpenSID/OpenSID/wiki/Aturan-Penulisan-Script)
- [x] I have followed [pull request review process](https://github.com/OpenSID/OpenSID/wiki/proses-review-pull-request)
- [x] Manual testing has been done in development environment
- [x] No console errors or warnings

## Technical Details

### Technical Explanation

Perubahan dilakukan pada file `database/seeders/IdentitasSeeder.php`. Data array `$defaultData` diubah dari data hardcoded Kota Bima menjadi data placeholder generik. Selain itu, `return` statement dihapus karena method `run()` pada Seeder seharusnya return `void`.

```php
// Before
$defaultData = [
    'nama_aplikasi' => 'Simatik',
    'nama_kabupaten' => 'KOTA BIMA',
    'kode_kabupaten' => '52.72',
    'nama_provinsi' => 'Nusa Tenggara Barat',
    'kode_provinsi' => '52',
    'sebutan_kab' => 'Kota'
];
return Identitas::create($defaultData);

// After
$defaultData = [
    'nama_aplikasi' => 'OpenKab',
    'nama_kabupaten' => 'Belum Ditentukan',
    'kode_kabupaten' => '00.00',
    'nama_provinsi' => 'Belum Ditentukan',
    'kode_provinsi' => '00',
    'sebutan_kab' => 'Kabupaten'
];
Identitas::create($defaultData);
```

### Dependencies added
- No new dependencies

## Testing

### Manual Testing
- [x] Jalankan fresh migration
- [x] Jalankan seeder `php artisan db:seed`
- [x] Verifikasi data identitas di tabel `identitas` adalah data generik
- [x] Akses aplikasi dan pastikan tidak ada error

## Video

https://github.com/user-attachments/assets/1e85b25e-a21b-4ec4-885a-b24a46819df9

https://github.com/user-attachments/assets/27673e5d-8d4d-40ff-a647-2acc8bb5eeb7

None

## Migration Guide

Not required

## References
- [GitHub Issue #1270](https://github.com/OpenSID/OpenKab/issues/1270)

---

**Additional notes:** Perubahan ini bersifat backward-compatible. Pengguna yang sudah memiliki data identitas tidak akan terpengaruh karena seeder hanya berjalan pada fresh install.
